### PR TITLE
ENA-6517: We should not override the locus_tag qualifierwhen it is already present in the child feature

### DIFF
--- a/src/main/java/uk/ac/ebi/embl/converter/fftogff3/GFF3AnnotationFactory.java
+++ b/src/main/java/uk/ac/ebi/embl/converter/fftogff3/GFF3AnnotationFactory.java
@@ -253,7 +253,8 @@ public class GFF3AnnotationFactory {
                 orderRootAndChildren(gffFeatures, child);
             } else {
                 // Leaf node processing
-                if (locusTag != null) {
+                if (locusTag != null && child.getAttributes().get("locus_tag")==null) {
+                    // Add parent's locus_tag only when it is not present in children
                     child.getAttributes().put("locus_tag", locusTag);
                 }
                 child.getAttributes().remove("gene");

--- a/src/test/resources/fftogff3_rules/locus_tag.embl
+++ b/src/test/resources/fftogff3_rules/locus_tag.embl
@@ -13,6 +13,9 @@ FT                   /gene="matK"
 FT                   /locus_tag="test"
 FT   mRNA            1..822
 FT                   /gene="matK"
+FT   mRNA            1000..8220
+FT                   /gene="matK"
+FT                   /locus_tag="different-locus"
 XX
 //
 

--- a/src/test/resources/fftogff3_rules/locus_tag.gff3
+++ b/src/test/resources/fftogff3_rules/locus_tag.gff3
@@ -2,3 +2,4 @@
 ##sequence-region TEST01.1 1 822
 TEST01.1	.	ncRNA_gene	1	822	.	+	.	ID=ncRNA_gene_matK;gene=matK;locus_tag=test;
 TEST01.1	.	mRNA	1	822	.	+	.	Parent=ncRNA_gene_matK;locus_tag=test;
+TEST01.1	.	mRNA	1000	8220	.	+	.	Parent=ncRNA_gene_matK;locus_tag=different-locus;


### PR DESCRIPTION
We should not override the locus_tag qualifier when it is already present in the child feature