### PR TITLE
Error handling documentation & Tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.9'
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.mockito:mockito-core:5.12.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
+
 }
 
 remotes {

--- a/docs/0000_design_document_template.md
+++ b/docs/0000_design_document_template.md
@@ -1,0 +1,70 @@
+- Feature Name: (fill me in with the feature name, `my_awesome_feature_design`)
+- Document Date: (fill me in with today's date, YYYY-MM-DD)
+- Last Updated: (fill me in with the last update date, YYYY-MM-DD)
+
+# Summary
+
+One paragraph explanation of the implemented feature or system. What does it do?
+
+# Motivation & Rationale
+
+Explain the problem this feature/system was designed to solve. Why was it built? What specific use cases does it address?
+Detail the rationale behind the chosen design. Why was this particular approach taken over others? What were the key considerations and trade-offs? This section should clearly articulate the "why" behind the implementation.
+
+# Usage Guidelines
+
+Explain how to use or interact with the implemented feature/system. This could include:
+- How to configure it.
+- How to extend it (e.g., adding new components, subclasses, or rules).
+- Best practices for common use cases.
+- Any specific conventions or patterns to follow.
+
+# System Overview / High-Level Design
+
+Explain the feature/system at a high level, as if you were explaining it to another developer who needs to understand its core components and how they interact.
+- Introduce new named concepts or modules.
+- Describe the main components and their responsibilities.
+- Include architectural diagrams (e.g., block diagrams, data flow diagrams) or describe where such diagrams can be found (e.g., link to an external Lucidchart/Excalidraw diagram).
+- Explain how this feature integrates with existing parts of the system.
+
+# Detailed Design & Implementation
+
+This is the technical portion of the document, explaining the actual implementation details.
+- Describe the key classes, functions, or services involved.
+- Explain important algorithms or data structures used.
+- Detail significant implementation decisions, including specific libraries or technologies chosen and why.
+- Discuss how specific corner cases or error conditions are handled.
+- If applicable, provide code snippets or links to key code sections that illustrate complex logic.
+- Explain how the design addresses the examples or use cases from the "Motivation & Rationale" section.
+
+
+# Alternatives Considered
+
+Briefly describe other significant design approaches that were considered during the RFC or design phase, and explain why they were not chosen. What were their drawbacks compared to the chosen solution?
+
+# Technical Debt / Future Considerations
+
+- What known limitations or technical debt exist within this implementation?
+- What are the potential future extensions or improvements for this feature/system?
+- Are there any related issues or features that are out of scope for the current implementation but might be addressed later?
+
+# Testing Strategy
+
+Describe how this feature/system is tested.
+- What types of tests are in place (unit, integration, end-to-end)?
+- Are there any specific testing frameworks or methodologies used?
+- How can a developer verify the correct functioning of this feature?
+
+# Deployment & Operations
+
+- How is this feature/system deployed?
+- Are there any specific operational considerations (e.g., monitoring, logging, scaling)?
+- What are the dependencies for deployment?
+
+# Related Documentation & Resources
+
+- Links to the original RFC (if applicable).
+- Links to relevant code repositories or directories.
+- Links to external libraries, APIs, or documentation that are critical for understanding this feature.
+- Links to monitoring dashboards, alerts, or runbooks related to this feature.
+

--- a/docs/0001_error_handling.md
+++ b/docs/0001_error_handling.md
@@ -107,6 +107,46 @@ The error handling strategy centers around the `ExitException` abstract class, w
     }
     ```
 
+**Flow diagram**
+```mermaid
+
+graph TD
+
+    subgraph Error Flow
+        E[Error Occurs] --> F{Throw ExitException Subclass}
+        F --> G[Main Class]
+    end
+
+    subgraph Centralized Handling
+        G --> I[ExecutionExceptionHandler]
+        I --> J{Is cause ExitException?}
+        J -- Yes --> K[Get CLIExitCode from ExitException]
+        J -- No --> O
+        G --> M{Catch OutOfMemoryError?}
+        M -- Yes --> N[Set exitCode = CLIExitCode.OUT_OF_MEMORY]
+        M -- No --> O{Catch General Throwable?}
+        O -- Yes --> P[Log error, default exit code]
+    end
+
+    K --> Q[System.exit]
+    N --> Q
+    P --> Q
+```
+
+### ExitException Hierarchy and New Entity Addition
+
+```mermaid
+ graph TD
+
+    subgraph Adding New Entities
+        H[New CLIExitCode Value]
+        I[New Top-Level ExitException]
+
+        H -- implemented by --> I
+        I -- extends --> K[Detailed Exception]
+    end
+```
+
 This system ensures a clear separation of error types, immediate insight into program exit behavior via exception types, and centralized control over `System.exit()` calls.
 
 # Detailed Design & Implementation

--- a/docs/0001_error_handling.md
+++ b/docs/0001_error_handling.md
@@ -203,16 +203,8 @@ The `Main` class integrates with `picocli` via `CommandLine.setExecutionExceptio
     *   **Implications:** This can lead to a less differentiated type system. Subclassing `ExitException` provides for more specific `catch` blocks and compile-time checks. The use of distinct type names, such as `ReadException`, can also provide more immediate information regarding the nature of the error.
 
 # Technical Debt / Future Considerations
-*   **Missing Test Coverage:** Implement comprehensive unit and integration tests for `ExitException` subclasses to verify `CLIExitCode` and constructor behavior, as well as the `Main` class's exception handling, as outlined in the Testing Strategy section.
-*   **Expansion of `CLIExitCode`:** Assess if additional standard `CLIExitCode` values are required to cover future error scenarios.
-*   **Error Reporting Framework:** Extend error handling to include more sophisticated error reporting, such as logging errors to a file, sending reports to a centralized service.
-
-# Testing Strategy
-
-The current testing strategy for this error handling system includes:
-*   **Unit Tests:** Existing unit tests primarily focus on command-line argument parsing and validation rules within `MainTest.java`. Dedicated unit tests for each `ExitException` subclass to verify the correctness of their `exitCode()` method and constructors are currently not comprehensively implemented.
-*   **Integration Tests:** Integration tests aim to verify that throwing an `ExitException` correctly results in the program exiting with the expected `CLIExitCode` when executed via the `Main` class. These tests should cover scenarios for `CLIException`, `ReadException`, `ValidationException`, `OutOfMemoryError`, and general `Throwable` catches. Comprehensive tests directly asserting `System.exit()` behavior for all `ExitException` types are not yet fully in place.
-*   **End-to-End Tests:** Command-line tool tests should validate that specific erroneous inputs or conditions lead to the expected exit code, simulating real-world usage.
+*   **Expansion of `CLIExitCode`:** The current `CLIExitCode` values are generally sufficient for existing error scenarios, and expansion is not an immediate high priority, though future assessment for truly distinct error categories is always open.
+*   **Error Reporting Framework:** Extend error handling to include more sophisticated error reporting, such as logging errors to a file, sending reports to a centralized service. The current implementation primarily uses standard SLF4J logging, and more advanced reporting mechanisms are still a future consideration.
 
 # Deployment & Operations
 

--- a/docs/0001_error_handling.md
+++ b/docs/0001_error_handling.md
@@ -1,0 +1,189 @@
+- Feature Name: error_handling_methodology
+- Document Date: 2025-07-08
+- Last Updated: 2025-07-08
+
+# Summary
+
+This document formalizes the existing custom error handling methodology within the project, which is built upon a hierarchy of `ExitException` classes and the use of `CLIExitCode` for structured program exits. This approach ensures consistent error reporting and allows for specific exit codes based on the type of error encountered, crucial for reliable automation and debugging.
+
+# Motivation & Rationale
+
+The motivation for this error handling methodology is rooted in the need for robust and predictable error reporting within the CLI tool. This includes ensuring standardized exit codes for seamless integration into automation pipelines, providing clear and actionable feedback to end-users, and controlling the display of stack traces based on error type, which facilitates bug reporting for unexpected issues. The exception hierarchy is designed to support fine-grained error differentiation to meet these requirements.
+
+This design addresses the following aspects:
+*   **Standardized Exit Codes for Automation:** The implementation of standardized exit codes aims to improve the integration of the CLI tool within automation pipelines. The use of `CLIExitCode` with `ExitException` establishes a mechanism for command-line tool errors to result in defined and machine-readable exit codes, supporting automated processing and decision-making. For instance, an exit code can indicate a read error (`CLIExitCode.READ_ERROR`), a validation error (`CLIExitCode.VALIDATION_ERROR`), or a command-line argument error (`CLIExitCode.USAGE`).
+*   **User-Centric Error Reporting:** The system provides user-friendly error messages that include a clear call to action for end users. Stack traces are suppressed for most errors, being displayed only for unidentified bugs, where the expected user action is to submit a bug report. The `ExitException` hierarchy facilitates fine-grained exception reporting, which supports this requirement.
+*   **Consistent Exception Usage:** Guidelines for extending `ExitException` and defining custom error types provide a framework for uniformity. For example, the addition of a new validation rule involves the use or extension of `ValidationException` with a relevant `ValidationRule` and message.
+*   **Enhanced Maintainability and Readability:** A defined error handling strategy contributes to the comprehensibility and debugging of the codebase. Error propagation and handling follow established patterns. In the event of an unexpected program termination, the `ExitException` hierarchy and `CLIExitCode` system provide information for root cause analysis.
+
+# Usage Guidelines
+
+## Adding New `ExitException` Subclasses
+
+When a new error scenario requires a specific program exit code and does not fit into existing `ExitException` subclasses, a new subclass should be created. Follow these guidelines:
+
+1.  **When to Add New `CLIExitCode` Values:** New `CLIExitCode` values should only be added when a truly distinct category of error emerges that cannot be logically grouped under existing codes. When adding a new code, consider the numerical spacing in the `CLIExitCode` enum (e.g., `READ_ERROR(10), WRITE_ERROR(11), NON_EXISTENT_FILE(12)`). This spacing allows for future expansion within a logical category (e.g., `13`, `14` for other IO errors). DO NOT RENUMBER EXISTING CODES, this would be a breaking change for automation pipelines.
+2.  **Single `CLIExitCode` Implementation:** For each distinct `CLIExitCode`, only one direct `ExitException` subclass should implement the `exitCode()` method to return that specific `CLIExitCode`.
+3.  **Inheritance for Related Exceptions:** If multiple exception classes logically correspond to the same `CLIExitCode`, they should extend the `ExitException` subclass that already implements that `CLIExitCode`. This ensures consistent exit behavior and reduces boilerplate.
+4.  **Extend `ExitException`:** The new exception class must extend `uk.ac.ebi.embl.converter.exception.ExitException` or one of its existing subclasses.
+5.  **Implement or Inherit `exitCode()`:** If the new exception is the *primary* class for a `CLIExitCode`, it must override the `exitCode()` method to return the chosen `CLIExitCode`. If it extends an existing `ExitException` subclass that already defines the appropriate `CLIExitCode`, there is no need to override `exitCode()`.
+
+**Example: Extending `ValidationException` for a specific validation failure**
+
+If a new validation rule, `InvalidFeatureIdRule`, requires a distinct exception that still falls under the `VALIDATION_ERROR` category, it can extend `ValidationException` and inherit its `CLIExitCode.VALIDATION_ERROR`.
+
+```java
+public class InvalidFeatureIdException extends ValidationException {
+    public InvalidFeatureIdException(String message) {
+        super(message);
+    }
+    // No need to override exitCode() if it inherits CLIExitCode.VALIDATION_ERROR
+}
+```
+
+**Example: Creating a new top-level `ExitException` for a new `CLIExitCode`**
+
+If a new error type, for example, related to configuration issues, needs a new `CLIExitCode` (e.g., `CLIExitCode.CONFIGURATION_ERROR`), a new top-level `ExitException` subclass would be created to implement this specific exit code:
+
+```java
+public class ConfigurationException extends ExitException {
+    public ConfigurationException(String message) {
+        super(message);
+    }
+
+    @Override
+    public CLIExitCode exitCode() {
+        return CLIExitCode.CONFIGURATION_ERROR; // Assumes CONFIGURATION_ERROR is defined in CLIExitCode
+    }
+}
+```
+
+
+# System Overview / High-Level Design
+
+The error handling strategy centers around the `ExitException` abstract class, which extends `java.lang.Exception`. Any error intended to cause a program exit with a specific status code must be a subclass of `ExitException`.
+
+**Key Concepts:**
+
+*   **`ExitException`:** The base class for all application-specific exceptions that should trigger a program exit with a defined status code.
+*   **`CLIExitCode`:** An enum defining standardized integer exit codes for different error types (e.g., `READ_ERROR`, `WRITE_ERROR`, `VALIDATION_ERROR`, `USAGE`, `SUCCESS`, `OUT_OF_MEMORY`). Each `ExitException` subclass must implement the `exitCode()` method to return the appropriate `CLIExitCode`.
+
+**Flow of Error Handling:**
+1.  **Define Custom Exceptions:** For new error scenarios requiring a specific exit code, a new class extending `ExitException` is created.
+    ```java
+    public class MyCustomErrorException extends ExitException {
+        public MyCustomErrorException(String message) {
+            super(message);
+        }
+
+        @Override
+        public CLIExitCode exitCode() {
+            return CLIExitCode.GENERAL; // Using GENERAL for a generic custom error
+        }
+    }
+    ```
+2.  **Throw Exceptions:** When an error occurs, the appropriate `ExitException` subclass is thrown.
+    ```java
+    if (invalidCondition) {
+        throw new CLIException("Invalid command line argument provided.");
+    }
+    ```
+3.  **Centralized Handling (in `Main` class):** The `Main` class's `main` method utilizes a `CommandLine.ExecutionExceptionHandler` to catch `ExitException` instances. This handler extracts the `CLIExitCode` for the program's exit status. 
+    ```java
+    public static void main(String[] args) {
+        int exitCode = 1; // Default error code
+        try {
+            exitCode = new CommandLine(new Main())
+                    .setExecutionExceptionHandler(new ExecutionExceptionHandler())
+                    .execute(args);
+        } catch (OutOfMemoryError e) {
+            // Specific handling for out of memory
+            exitCode = CLIExitCode.OUT_OF_MEMORY.asInt();
+        } catch (Throwable e) {
+            // General catch-all for unexpected errors
+            LOG.error(e.getMessage(), e);
+        }
+        System.exit(exitCode);
+    }
+    ```
+
+This system ensures a clear separation of error types, immediate insight into program exit behavior via exception types, and centralized control over `System.exit()` calls.
+
+# Detailed Design & Implementation
+
+The core components are `uk.ac.ebi.embl.converter.exception.ExitException` and `uk.ac.ebi.embl.converter.cli.CLIExitCode`.
+
+**`uk.ac.ebi.embl.converter.exception.ExitException`:**
+*   An abstract class extending `java.lang.Exception`.
+*   Abstract method: `public abstract CLIExitCode exitCode();`: Must be implemented by subclasses to provide the specific exit code.
+
+**`uk.ac.ebi.embl.converter.cli.CLIExitCode`:**
+*   An enum defining integer exit codes.
+*   Each enum constant represents a specific exit status (e.g., `GENERAL(1)`, `USAGE(2)`, `UNSUPPORTED_FORMAT_CONVERSION(3)`, `READ_ERROR(10)`, `WRITE_ERROR(11)`, `NON_EXISTENT_FILE(12)`, `VALIDATION_ERROR(20)`, `OUT_OF_MEMORY(30)`).
+*   Provides `asInt()` method to retrieve the integer value.
+
+**Example Implementations:**
+
+*   **`uk.ac.ebi.embl.converter.exception.ValidationException`:**
+    ```java
+    public class ValidationException extends ExitException {
+        // ... constructors and methods
+        @Override
+        public CLIExitCode exitCode() {
+            return CLIExitCode.VALIDATION_ERROR;
+        }
+    }
+    ```
+    Used for data validation failures, potentially including details like line number and validation rule.
+
+
+*   **`uk.ac.ebi.embl.converter.exception.InvalidGFF3HeaderException`:**
+    ```java
+    public class InvalidGFF3HeaderException extends ValidationException {
+        public InvalidGFF3HeaderException(String message) {
+            super(message);
+        }
+    }
+    ```
+    Used for invalid GFF3 header errors.
+
+**Interaction with `picocli`:**
+The `Main` class integrates with `picocli` via `CommandLine.setExecutionExceptionHandler`. The custom `ExecutionExceptionHandler` determines if the caught exception's cause is an `ExitException`. If so, it uses the `exitCode()` method to provide the appropriate integer for `System.exit()`, ensuring that all `ExitException` subclasses contribute correctly to the program's exit status.
+
+# Alternatives Considered
+
+1.  **Using `System.exit()` directly at every error point:**
+    *   **Characteristics:** This approach involves direct calls to `System.exit()` at various error points within the codebase.
+    *   **Implications:** This can result in dispersed program exit points, variations in exit codes, and increased complexity in tracing program exits and performing necessary cleanup operations prior to exit. Testing of error conditions may also present challenges.
+2.  **Relying solely on standard Java exceptions (e.g., `IOException`, `IllegalArgumentException`) and catching them in `Main`:**
+    *   **Characteristics:** This approach uses standard Java exceptions for error propagation, with a central catch block in the `Main` method.
+    *   **Implications:** Standard exceptions do not inherently convey semantic meaning related to command-line tool exit codes. The mapping of each standard exception to a specific exit code within the `Main` method can be extensive and less explicit. This approach may also result in less specific error messages for the user.
+3.  **Using a single generic `ToolException` with an `exitCode` field:**
+    *   **Characteristics:** This approach involves a single, generic exception class that includes an `exitCode` field.
+    *   **Implications:** This can lead to a less differentiated type system. Subclassing `ExitException` provides for more specific `catch` blocks and compile-time checks. The use of distinct type names, such as `ReadException`, can also provide more immediate information regarding the nature of the error.
+
+# Technical Debt / Future Considerations
+*   **Missing Test Coverage:** Implement comprehensive unit and integration tests for `ExitException` subclasses to verify `CLIExitCode` and constructor behavior, as well as the `Main` class's exception handling, as outlined in the Testing Strategy section.
+*   **Expansion of `CLIExitCode`:** Assess if additional standard `CLIExitCode` values are required to cover future error scenarios.
+*   **Error Reporting Framework:** Extend error handling to include more sophisticated error reporting, such as logging errors to a file, sending reports to a centralized service.
+
+# Testing Strategy
+
+The current testing strategy for this error handling system includes:
+*   **Unit Tests:** Existing unit tests primarily focus on command-line argument parsing and validation rules within `MainTest.java`. Dedicated unit tests for each `ExitException` subclass to verify the correctness of their `exitCode()` method and constructors are currently not comprehensively implemented.
+*   **Integration Tests:** Integration tests aim to verify that throwing an `ExitException` correctly results in the program exiting with the expected `CLIExitCode` when executed via the `Main` class. These tests should cover scenarios for `CLIException`, `ReadException`, `ValidationException`, `OutOfMemoryError`, and general `Throwable` catches. Comprehensive tests directly asserting `System.exit()` behavior for all `ExitException` types are not yet fully in place.
+*   **End-to-End Tests:** Command-line tool tests should validate that specific erroneous inputs or conditions lead to the expected exit code, simulating real-world usage.
+
+# Deployment & Operations
+
+*   **Deployment:** The error handling mechanism is an integral part of the application's core logic and is deployed with the application itself. No special deployment steps are required beyond standard application deployment.
+
+# Related Documentation & Resources
+
+*   `uk.ac.ebi.embl.converter.exception.ExitException`
+*   `uk.ac.ebi.embl.converter.cli.CLIExitCode`
+*   `uk.ac.ebi.embl.converter.exception.CLIException`
+*   `uk.ac.ebi.embl.converter.exception.ReadException`
+*   `uk.ac.ebi.embl.converter.exception.ValidationException`
+*   `picocli` documentation: [https://picocli.info/](https://picocli.info/)
+

--- a/src/main/java/uk/ac/ebi/embl/converter/cli/ExecutionExceptionHandler.java
+++ b/src/main/java/uk/ac/ebi/embl/converter/cli/ExecutionExceptionHandler.java
@@ -17,6 +17,7 @@ import picocli.CommandLine.IExecutionExceptionHandler;
 import picocli.CommandLine.ParseResult;
 import uk.ac.ebi.embl.converter.exception.ExitException;
 
+// All the exceptions for this tool are handled here. An appropriate exit code is returned in case of handled errors.
 public class ExecutionExceptionHandler implements IExecutionExceptionHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(ExecutionExceptionHandler.class);

--- a/src/main/java/uk/ac/ebi/embl/converter/cli/ExecutionExceptionHandler.java
+++ b/src/main/java/uk/ac/ebi/embl/converter/cli/ExecutionExceptionHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.converter.cli;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import picocli.CommandLine.IExecutionExceptionHandler;
+import picocli.CommandLine.ParseResult;
+import uk.ac.ebi.embl.converter.exception.ExitException;
+
+public class ExecutionExceptionHandler implements IExecutionExceptionHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExecutionExceptionHandler.class);
+
+    @Override
+    public int handleExecutionException(Exception e, CommandLine commandLine, ParseResult parseResult)
+            throws Exception {
+        if (e.getCause() instanceof ExitException) {
+            LOG.error(e.getMessage());
+            return ((ExitException) e.getCause()).exitCode().asInt();
+        }
+        throw e;
+    }
+}

--- a/src/main/java/uk/ac/ebi/embl/converter/exception/NonExistingFile.java
+++ b/src/main/java/uk/ac/ebi/embl/converter/exception/NonExistingFile.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.converter.exception;
+
+import java.io.IOException;
+import uk.ac.ebi.embl.converter.cli.CLIExitCode;
+
+public class NonExistingFile extends ExitException {
+    public NonExistingFile(String msg, IOException cause) {
+        super(msg, cause);
+    }
+
+    public NonExistingFile(IOException cause) {
+        super("The input file does not exist", cause);
+    }
+
+    @Override
+    public CLIExitCode exitCode() {
+        return CLIExitCode.NON_EXISTENT_FILE;
+    }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,5 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- We only want on stdout INFO or less unfortunatelly ThresholdFilter doesn't work for this-->
         <encoder>
             <pattern>%d{YYYY-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
@@ -8,9 +9,15 @@
             <onMatch>DENY</onMatch>
             <onMismatch>NEUTRAL</onMismatch>
         </filter>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>DENY</onMatch>
+            <onMismatch>NEUTRAL</onMismatch>
+        </filter>
     </appender>
 
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- We only want on stderr WARN or greater-->
         <target>System.err</target>
         <encoder>
             <pattern>%d{YYYY-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>

--- a/src/test/java/uk/ac/ebi/embl/converter/cli/MainIntegrationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/converter/cli/MainIntegrationTest.java
@@ -54,9 +54,18 @@ public class MainIntegrationTest {
     @Test
     void testReadExceptionExitCode() {
         String[] args = new String[] {"conversion", "-f", "embl", "-t", "gff3", "non_existent_input.embl"}; //
-        // mainMockedStatic.verify(() -> Main.exit(CLIExitCode.USAGE.asInt()));
-        // Main.main(args);
-        // mainMockedStatic.verify(() -> Main.exit(CLIExitCode.READ_ERROR.asInt()));
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(errContent));
+
+        try (MockedStatic<Main> mock = mockStatic(Main.class)) {
+            mock.when(() -> Main.main(any())).thenCallRealMethod();
+            mock.when(() -> Main.exit(anyInt())).thenAnswer((Answer<Void>) i -> null);
+            Main.main(args);
+            mock.verify(() -> Main.exit(CLIExitCode.NON_EXISTENT_FILE.asInt()));
+        } finally {
+            System.setErr(originalErr);
+        }
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/embl/converter/cli/MainIntegrationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/converter/cli/MainIntegrationTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.converter.cli;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mockStatic;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.stubbing.Answer;
+
+public class MainIntegrationTest {
+
+    @BeforeEach
+    void setup() {}
+
+    @AfterEach
+    void tearDown() {}
+
+    @Test
+    void testCLIExceptionExitCode() {
+        String[] args = new String[] {"conversion", "-f", "invalid_format", "-t", "gff3", "input.gff3"};
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(errContent));
+
+        try (MockedStatic<Main> mock = mockStatic(Main.class)) {
+            mock.when(() -> Main.main(any())).thenCallRealMethod();
+            mock.when(() -> Main.exit(anyInt())).thenAnswer((Answer<Void>) i -> null);
+            Main.main(args);
+            mock.verify(() -> Main.exit(CLIExitCode.USAGE.asInt()));
+        } finally {
+            System.setErr(originalErr);
+        }
+    }
+
+    @Test
+    void testReadExceptionExitCode() {
+        String[] args = new String[] {"conversion", "-f", "embl", "-t", "gff3", "non_existent_input.embl"}; //
+        // mainMockedStatic.verify(() -> Main.exit(CLIExitCode.USAGE.asInt()));
+        // Main.main(args);
+        // mainMockedStatic.verify(() -> Main.exit(CLIExitCode.READ_ERROR.asInt()));
+    }
+
+    @Test
+    void testValidationExceptionExitCode() throws IOException {
+        // Create a temporary file with an invalid GFF3 header to trigger
+        // ValidationException
+        Path tempFile = Files.createTempFile("invalid_gff3", ".gff3");
+        Files.writeString(tempFile, "This is an invalid file\n");
+
+        String[] args = new String[] {"conversion", "-f", "gff3", "-t", "embl", tempFile.toString()};
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(errContent));
+
+        try (MockedStatic<Main> mock = mockStatic(Main.class)) {
+            mock.when(() -> Main.main(any())).thenCallRealMethod();
+            mock.when(() -> Main.exit(anyInt())).thenAnswer((Answer<Void>) i -> null);
+            Main.main(args);
+            mock.verify(() -> Main.exit(CLIExitCode.VALIDATION_ERROR.asInt()));
+            assertTrue(
+                    errContent
+                            .toString()
+                            .contains(
+                                    "Violation of rule GFF3_INVALID_HEADER on line 1: Invalid gff3 header (This is an invalid file)"));
+        } finally {
+            Files.deleteIfExists(tempFile);
+            System.setErr(originalErr);
+        }
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/converter/exception/CLIExceptionTest.java
+++ b/src/test/java/uk/ac/ebi/embl/converter/exception/CLIExceptionTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.converter.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.converter.cli.CLIExitCode;
+
+public class CLIExceptionTest {
+
+    @Test
+    void testConstructor_messageOnly() {
+        String message = "Invalid command line argument.";
+        CLIException exception = new CLIException(message);
+        assertEquals(message, exception.getMessage());
+        assertNull(exception.getCause());
+        assertEquals(CLIExitCode.USAGE, exception.exitCode());
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/converter/exception/ExitExceptionTest.java
+++ b/src/test/java/uk/ac/ebi/embl/converter/exception/ExitExceptionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.converter.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.converter.cli.CLIExitCode;
+
+public class ExitExceptionTest {
+
+    // Anonymous inner class to test the abstract ExitException
+    private static class TestExitException extends ExitException {
+        public TestExitException(String message) {
+            super(message);
+        }
+
+        public TestExitException(String message, Exception cause) {
+            super(message, cause);
+        }
+
+        @Override
+        public CLIExitCode exitCode() {
+            return CLIExitCode.GENERAL; // A generic exit code for testing
+        }
+    }
+
+    @Test
+    void testConstructor_messageOnly() {
+        String message = "Test message";
+        TestExitException exception = new TestExitException(message);
+        assertEquals(message, exception.getMessage());
+        assertNull(exception.getCause());
+        assertEquals(CLIExitCode.GENERAL, exception.exitCode());
+    }
+
+    @Test
+    void testConstructor_messageAndCause() {
+        String message = "Test message with cause";
+        Exception cause = new RuntimeException("Original cause");
+        TestExitException exception = new TestExitException(message, cause);
+        assertEquals(message, exception.getMessage());
+        assertEquals(cause, exception.getCause());
+        assertEquals(CLIExitCode.GENERAL, exception.exitCode());
+    }
+
+    @Test
+    void testExitCode() {
+        TestExitException exception = new TestExitException("Any message");
+        assertEquals(CLIExitCode.GENERAL, exception.exitCode());
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/converter/exception/FormatSupportExceptionTest.java
+++ b/src/test/java/uk/ac/ebi/embl/converter/exception/FormatSupportExceptionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.converter.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.converter.cli.CLIExitCode;
+import uk.ac.ebi.embl.converter.cli.ConversionFileFormat;
+
+public class FormatSupportExceptionTest {
+
+    @Test
+    void testConstructor() {
+        ConversionFileFormat fromFt = ConversionFileFormat.embl;
+        ConversionFileFormat toFt = ConversionFileFormat.gff3;
+        FormatSupportException exception = new FormatSupportException(fromFt, toFt);
+
+        assertEquals("Conversion from \"embl\" to \"gff3\" is not supported", exception.getMessage());
+        assertNull(exception.getCause());
+        assertEquals(CLIExitCode.UNSUPPORTED_FORMAT_CONVERSION, exception.exitCode());
+    }
+
+    @Test
+    void testExitCode() {
+        FormatSupportException exception =
+                new FormatSupportException(ConversionFileFormat.embl, ConversionFileFormat.gff3);
+        assertEquals(CLIExitCode.UNSUPPORTED_FORMAT_CONVERSION, exception.exitCode());
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/converter/exception/InvalidGFF3HeaderExceptionTest.java
+++ b/src/test/java/uk/ac/ebi/embl/converter/exception/InvalidGFF3HeaderExceptionTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.converter.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.converter.cli.CLIExitCode;
+import uk.ac.ebi.embl.converter.validation.ValidationRule;
+
+public class InvalidGFF3HeaderExceptionTest {
+
+    @Test
+    void testConstructor_lineAndMessage() {
+        int line = 5;
+        String message = "Missing GFF3 version directive.";
+        InvalidGFF3HeaderException exception = new InvalidGFF3HeaderException(line, message);
+
+        assertEquals(
+                "Violation of rule GFF3_INVALID_HEADER on line 5: Invalid gff3 header (%s)".formatted(message),
+                exception.getMessage());
+        assertEquals(line, exception.getLine());
+        assertEquals(ValidationRule.GFF3_INVALID_HEADER, exception.getValidationRule());
+        assertEquals(CLIExitCode.VALIDATION_ERROR, exception.exitCode());
+        assertNull(exception.getCause());
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/converter/exception/InvalidGFF3RecordExceptionTest.java
+++ b/src/test/java/uk/ac/ebi/embl/converter/exception/InvalidGFF3RecordExceptionTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.converter.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.converter.cli.CLIExitCode;
+import uk.ac.ebi.embl.converter.validation.ValidationRule;
+
+public class InvalidGFF3RecordExceptionTest {
+
+    @Test
+    void testConstructor_lineAndMessage() {
+        int line = 15;
+        String message = "Invalid number of columns.";
+        InvalidGFF3RecordException exception = new InvalidGFF3RecordException(line, message);
+
+        assertEquals(
+                "Violation of rule GFF3_INVALID_RECORD on line 15: The record does not conform with the expected gff3 format (%s)"
+                        .formatted(message),
+                exception.getMessage());
+        assertEquals(line, exception.getLine());
+        assertEquals(ValidationRule.GFF3_INVALID_RECORD, exception.getValidationRule());
+        assertEquals(CLIExitCode.VALIDATION_ERROR, exception.exitCode());
+        assertNull(exception.getCause());
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/converter/exception/NoSourcePresentExceptionTest.java
+++ b/src/test/java/uk/ac/ebi/embl/converter/exception/NoSourcePresentExceptionTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.converter.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.converter.cli.CLIExitCode;
+import uk.ac.ebi.embl.converter.validation.ValidationRule;
+
+public class NoSourcePresentExceptionTest {
+
+    @Test
+    void testConstructor() {
+        NoSourcePresentException exception = new NoSourcePresentException();
+
+        assertEquals(
+                "Violation of rule FLATFILE_NO_SOURCE: The flatfile contains no source feature (No source present)",
+                exception.getMessage());
+        assertEquals(ValidationRule.FLATFILE_NO_SOURCE, exception.getValidationRule());
+        assertEquals(0, exception.getLine());
+        assertEquals(CLIExitCode.VALIDATION_ERROR, exception.exitCode());
+        assertNull(exception.getCause());
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/converter/exception/ReadExceptionTest.java
+++ b/src/test/java/uk/ac/ebi/embl/converter/exception/ReadExceptionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.converter.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.converter.cli.CLIExitCode;
+
+public class ReadExceptionTest {
+
+    @Test
+    void testConstructor_messageAndCause() {
+        String message = "Error reading file.";
+        IOException cause = new IOException("File not found");
+        ReadException exception = new ReadException(message, cause);
+        assertEquals(message, exception.getMessage());
+        assertEquals(cause, exception.getCause());
+        assertEquals(CLIExitCode.READ_ERROR, exception.exitCode());
+    }
+
+    @Test
+    void testConstructor_causeOnly() {
+        IOException cause = new IOException("Broken pipe");
+        ReadException exception = new ReadException(cause);
+        assertEquals("Error reading from input", exception.getMessage());
+        assertEquals(cause, exception.getCause());
+        assertEquals(CLIExitCode.READ_ERROR, exception.exitCode());
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/converter/exception/UnmappedFFFeatureExceptionTest.java
+++ b/src/test/java/uk/ac/ebi/embl/converter/exception/UnmappedFFFeatureExceptionTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.converter.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.converter.cli.CLIExitCode;
+import uk.ac.ebi.embl.converter.validation.ValidationRule;
+
+public class UnmappedFFFeatureExceptionTest {
+
+    @Test
+    void testConstructor() {
+        String featureName = "gene";
+        UnmappedFFFeatureException exception = new UnmappedFFFeatureException(featureName);
+
+        assertEquals(
+                "Violation of rule FLATFILE_NO_ONTOLOGY_FEATURE: The flatfile feature does not exist on the ontology. (%s)"
+                        .formatted(featureName),
+                exception.getMessage());
+        assertEquals(ValidationRule.FLATFILE_NO_ONTOLOGY_FEATURE, exception.getValidationRule());
+        assertEquals(0, exception.getLine());
+        assertEquals(CLIExitCode.VALIDATION_ERROR, exception.exitCode());
+        assertNull(exception.getCause());
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/converter/exception/ValidationExceptionTest.java
+++ b/src/test/java/uk/ac/ebi/embl/converter/exception/ValidationExceptionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.converter.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.converter.cli.CLIExitCode;
+import uk.ac.ebi.embl.converter.validation.ValidationRule;
+
+public class ValidationExceptionTest {
+
+    @Test
+    void testConstructor_ruleAndMessageOnly() {
+        ValidationRule rule = ValidationRule.GFF3_INVALID_RECORD;
+        String message = "Invalid format detected.";
+        ValidationException exception = new ValidationException(rule, message);
+
+        assertEquals(
+                "Violation of rule GFF3_INVALID_RECORD: The record does not conform with the expected gff3 format (%s)"
+                        .formatted(message),
+                exception.getMessage());
+        assertEquals(rule, exception.getValidationRule());
+        assertEquals(0, exception.getLine()); // Default line is 0
+        assertEquals(CLIExitCode.VALIDATION_ERROR, exception.exitCode());
+        assertNull(exception.getCause());
+    }
+
+    @Test
+    void testConstructor_ruleLineAndMessage() {
+        ValidationRule rule = ValidationRule.FLATFILE_NO_SOURCE;
+        int line = 10;
+        String message = "No source feature found.";
+        ValidationException exception = new ValidationException(rule, line, message);
+
+        assertEquals(
+                "Violation of rule FLATFILE_NO_SOURCE on line 10: The flatfile contains no source feature (%s)"
+                        .formatted(message),
+                exception.getMessage());
+        assertEquals(rule, exception.getValidationRule());
+        assertEquals(line, exception.getLine());
+        assertEquals(CLIExitCode.VALIDATION_ERROR, exception.exitCode());
+        assertNull(exception.getCause());
+    }
+
+    @Test
+    void testExitCode() {
+        ValidationException exception = new ValidationException(ValidationRule.GFF3_INVALID_RECORD, "Any message");
+        assertEquals(CLIExitCode.VALIDATION_ERROR, exception.exitCode());
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/converter/exception/WriteExceptionTest.java
+++ b/src/test/java/uk/ac/ebi/embl/converter/exception/WriteExceptionTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.converter.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.converter.cli.CLIExitCode;
+
+public class WriteExceptionTest {
+
+    @Test
+    void testConstructor_causeOnly() {
+        IOException cause = new IOException("Disk full");
+        WriteException exception = new WriteException(cause);
+        assertNotNull(exception.getMessage());
+        assertEquals("Error writing to output", exception.getMessage());
+        assertEquals(cause, exception.getCause());
+        assertEquals(CLIExitCode.WRITE_ERROR, exception.exitCode());
+    }
+}


### PR DESCRIPTION
- **Documentation:** Introduction of a design document template and a detailed error handling methodology document.
    - Documentation for error handling can be viewed on a rendered markdown document on this [link](https://github.com/enasequence/gff3tools/blob/00a002b38fb26f0cb81be17b08eda1064cc2488a/docs/0001_error_handling.md)
- **Error Handling Refinement:**
    - Centralization of exception handling in `Main.java` by moving `ExecutionExceptionHandler` to its own file.
    - Introduction of `NonExistingFile` exception for clearer error reporting when files are not found.
    - Refactoring `FileConversionCommand.java` to throw `ReadException` and `NonExistingFile` instead of generic `Error`.
    - Modification of `Main.java` to use `CLIExitCode.GENERAL` as the default exit code.
    - Addition of a new `exit` method in `Main.java` to allow mocking `System.exit()` in tests.
- **Testing:**
    - Addition of `mockito-core` and `mockito-junit-jupiter` dependencies for testing.
    - Introduction of `MainIntegrationTest.java` with tests for `CLIException`, `ReadException`, and `ValidationException` exit codes.
    - Addition of unit tests for various `ExitException` subclasses: `CLIExceptionTest`, `ExitExceptionTest`, `FormatSupportExceptionTest`, `InvalidGFF3HeaderExceptionTest`, `InvalidGFF3RecordExceptionTest`, `NoSourcePresentExceptionTest`, `ReadExceptionTest`, `UnmappedFFFeatureExceptionTest`, and `ValidationExceptionTest`.
- **Logging:** Modification of `logback.xml` to correctly separate INFO/DEBUG/TRACE/WARN/ERROR logs to STDOUT and STDERR respectively.
