### PR TITLE
Removes unnecesary join logic for excluded features.

### DIFF
--- a/src/main/java/uk/ac/ebi/embl/converter/gff3toff/GFF3Mapper.java
+++ b/src/main/java/uk/ac/ebi/embl/converter/gff3toff/GFF3Mapper.java
@@ -11,7 +11,6 @@
 package uk.ac.ebi.embl.converter.gff3toff;
 
 import java.util.*;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.ebi.embl.api.entry.Entry;
@@ -32,9 +31,6 @@ import uk.ac.ebi.embl.converter.utils.ConversionUtils;
 public class GFF3Mapper {
 
     private static final Logger LOG = LoggerFactory.getLogger(GFF3Mapper.class);
-
-    private static final Set<String> JOIN_EXCLUDED_FEATURES =
-            Set.of("protein_bind", "repeat_region", "assembly_gap", "misc_feature");
 
     private final Map<String, String> qmap = ConversionUtils.getGFF32FFQualifierMap();
     private final EntryFactory entryFactory = new EntryFactory();
@@ -129,11 +125,7 @@ public class GFF3Mapper {
             locations.addLocation(location);
             ffFeature.setLocations(locations);
             ffFeature.addQualifiers(mapGFF3Attributes(attributes));
-            // Only adds this feature to the map if is not one of the excluded features.
-            // This is so locations won't be merged on joins for the excluded features.
-            if (!JOIN_EXCLUDED_FEATURES.contains(featureName)) {
-                joinableFeatureMap.put(featureHashId, ffFeature);
-            }
+            joinableFeatureMap.put(featureHashId, ffFeature);
             entry.addFeature(ffFeature);
         }
         if (ffFeature.getQualifiers("gene").isEmpty()) {

--- a/src/test/resources/gff3toff_rules/join_excluded.gff3
+++ b/src/test/resources/gff3toff_rules/join_excluded.gff3
@@ -1,11 +1,11 @@
 ##gff-version 3.1.26
 ##sequence-region TEST01.1 1 1000
 TEST01.1	.	gene	1	1000	.	+	.	ID=gene_matK;gene=matK;
-TEST01.1	.	protein_bind	1	500	.	+	.	gene=matK;
-TEST01.1	.	protein_bind	100	150	.	+	.	gene=matK;
-TEST01.1	.	repeat_region	200	250	.	+	.	gene=matK;
-TEST01.1	.	repeat_region	300	350	.	+	.	gene=matK;
-TEST01.1	.	assembly_gap	400	450	.	+	.	gene=matK;
-TEST01.1	.	assembly_gap	500	550	.	+	.	gene=matK;
-TEST01.1	.	misc_feature	600	650	.	+	.	gene=matk;
-TEST01.1	.	misc_feature	700	750	.	+	.	gene=matK;
+TEST01.1	.	protein_bind	1	500	.	+	.	gene=matK;ID=protein_bind;
+TEST01.1	.	protein_bind	100	150	.	+	.	gene=matK;ID=protein_bind_1;
+TEST01.1	.	repeat_region	200	250	.	+	.	gene=matK;ID=repeat_region;
+TEST01.1	.	repeat_region	300	350	.	+	.	gene=matK;ID=repeat_region_1;
+TEST01.1	.	assembly_gap	400	450	.	+	.	gene=matK;ID=assembly_gap;
+TEST01.1	.	assembly_gap	500	550	.	+	.	gene=matK;ID=assembly_gap_1;
+TEST01.1	.	misc_feature	600	650	.	+	.	gene=matk;ID=misc_feature;
+TEST01.1	.	misc_feature	700	750	.	+	.	gene=matK;ID=misc_feature_1;


### PR DESCRIPTION
- Removed the `JOIN_EXCLUDED_FEATURES` set and associated logic from `GFF3Mapper.java` as it was superseded by the ID functionality.
- Updated `join_excluded.gff3` to include `ID` attributes for features, ensuring they are correctly joined in tests.
