### PR TITLE
Fix: Merge GFF3 annotations with `###` directive into single EMBL entry

### DIFF
--- a/src/main/java/uk/ac/ebi/embl/converter/gff3/GFF3Annotation.java
+++ b/src/main/java/uk/ac/ebi/embl/converter/gff3/GFF3Annotation.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -98,5 +99,28 @@ public class GFF3Annotation implements IGFF3Feature {
 
     public void addFeature(GFF3Feature feature) {
         features.add(feature);
+    }
+
+    public void merge(GFF3Annotation other) {
+        this.directives.getDirectives().addAll(other.directives.getDirectives());
+        this.features.addAll(other.features);
+    }
+
+    public String getAccession() {
+        Optional<GFF3Directives.GFF3SequenceRegion> directive = this.directives.getDirectives().stream()
+                .filter((d) -> {
+                    if (d instanceof GFF3Directives.GFF3SequenceRegion) {
+                        return true;
+                    }
+                    return false;
+                })
+                .map((d) -> (GFF3Directives.GFF3SequenceRegion) d)
+                .findFirst();
+        return directive
+                .map((d) -> d.accession())
+                .orElse(this.features.stream()
+                        .findFirst()
+                        .map(GFF3Feature::getAccession)
+                        .orElse(null));
     }
 }

--- a/src/main/java/uk/ac/ebi/embl/converter/gff3toff/Gff3ToFFConverter.java
+++ b/src/main/java/uk/ac/ebi/embl/converter/gff3toff/Gff3ToFFConverter.java
@@ -24,18 +24,46 @@ public class Gff3ToFFConverter implements Converter {
         try (GFF3FileReader gff3Reader = new GFF3FileReader(reader)) {
             GFF3Mapper mapper = new GFF3Mapper();
             gff3Reader.readHeader();
-            GFF3Annotation annotation;
-            while ((annotation = gff3Reader.readAnnotation()) != null) {
-                EmblEntryWriter entryWriter = new EmblEntryWriter(mapper.mapGFF3ToEntry(annotation));
-                entryWriter.setShowAcStartLine(false);
-                try {
-                    entryWriter.write(writer);
-                } catch (IOException e) {
-                    throw new WriteException(e);
+            GFF3Annotation previousAnnotation = null;
+            GFF3Annotation currentAnnotation;
+            // The GFF3 reader returns an annotation every time it encounters a '###' directive or when the accession
+            // number of a feature changes.
+            // Since an EMBL Flat File (FF) cannot have multiple entries with the same accession, all annotations
+            // pertaining to the same accession
+            // must be merged into a single EmblEntry before being written to the output.
+            while ((currentAnnotation = gff3Reader.readAnnotation()) != null) {
+                // Merge the annotations if the accession is the same
+                if (previousAnnotation != null
+                        && currentAnnotation.getAccession().equals(previousAnnotation.getAccession())) {
+                    previousAnnotation.merge(currentAnnotation);
+                } else {
+                    // The accession is different, so write the previous annotation to EMBL
+                    if (previousAnnotation != null) writeEntry(mapper, previousAnnotation, writer);
+                    previousAnnotation = currentAnnotation;
                 }
             }
+            // After the loop, write the last accumulated annotation.
+            if (previousAnnotation != null) writeEntry(mapper, previousAnnotation, writer);
         } catch (IOException e) {
             throw new ReadException(e);
+        }
+    }
+
+    /**
+     * Writes an EmblEntry to the provided BufferedWriter.
+     *
+     * @param mapper The GFF3Mapper instance used to convert GFF3Annotation to EmblEntry.
+     * @param annotation The GFF3Annotation to be written.
+     * @param writer The BufferedWriter to write the EmblEntry to.
+     * @throws WriteException if an error occurs during writing.
+     */
+    private void writeEntry(GFF3Mapper mapper, GFF3Annotation annotation, BufferedWriter writer) throws WriteException {
+        EmblEntryWriter entryWriter = new EmblEntryWriter(mapper.mapGFF3ToEntry(annotation));
+        entryWriter.setShowAcStartLine(false);
+        try {
+            entryWriter.write(writer);
+        } catch (IOException e) {
+            throw new WriteException(e);
         }
     }
 }

--- a/src/test/java/uk/ac/ebi/embl/converter/gff3/GFF3AnnotationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/converter/gff3/GFF3AnnotationTest.java
@@ -17,6 +17,7 @@ import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import uk.ac.ebi.embl.converter.TestUtils;
 import uk.ac.ebi.embl.converter.exception.WriteException;
@@ -85,5 +86,34 @@ public class GFF3AnnotationTest {
             assertTrue(mergedContent.contains("feature1"));
             assertTrue(mergedContent.contains("feature2"));
         }
+    }
+
+    @Test
+    public void testGetAccession() throws IOException, WriteException {
+        // Test case 1: Accession from GFF3SequenceRegion directive
+        GFF3Annotation annotation1 = new GFF3Annotation();
+        annotation1.getDirectives().add(new GFF3Directives.GFF3SequenceRegion("ACC00001", Optional.empty(), 1, 100));
+        assertEquals("ACC00001", annotation1.getAccession());
+
+        // Test case 2: Accession from the first feature when no GFF3SequenceRegion directive
+        GFF3Annotation annotation2 = new GFF3Annotation();
+        GFF3Feature feature2 = new GFF3Feature(
+                Optional.of("feature_id_2"),
+                Optional.empty(),
+                "ACC00002", // Accession
+                "source",
+                "type",
+                1,
+                100,
+                ".",
+                "+",
+                ".",
+                new HashMap<>());
+        annotation2.addFeature(feature2);
+        assertEquals("ACC00002", annotation2.getAccession());
+
+        // Test case 3: No accession (empty annotation)
+        GFF3Annotation annotation3 = new GFF3Annotation();
+        assertNull(annotation3.getAccession());
     }
 }

--- a/src/test/java/uk/ac/ebi/embl/converter/gff3/GFF3AnnotationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/converter/gff3/GFF3AnnotationTest.java
@@ -55,4 +55,35 @@ public class GFF3AnnotationTest {
             assertTrue(attr.endsWith(expectedAttribute));
         }
     }
+
+    @Test
+    public void testMergeAnnotations() throws IOException, WriteException {
+        // Create first annotation
+        GFF3Annotation annotation1 = new GFF3Annotation();
+        Map<String, Object> attributes1 = new HashMap<>();
+        attributes1.put("ID", "feature1");
+        GFF3Feature feature1 = TestUtils.createGFF3Feature("ID1", "Parent1", attributes1);
+        annotation1.addFeature(feature1);
+
+        // Create second annotation
+        GFF3Annotation annotation2 = new GFF3Annotation();
+        Map<String, Object> attributes2 = new HashMap<>();
+        attributes2.put("ID", "feature2");
+        GFF3Feature feature2 = TestUtils.createGFF3Feature("ID2", "Parent2", attributes2);
+        annotation2.addFeature(feature2);
+
+        // Merge annotations
+        annotation1.merge(annotation2);
+
+        // Assert merged content
+        try (StringWriter gff3Writer = new StringWriter()) {
+            annotation1.writeGFF3String(gff3Writer);
+            String mergedContent = gff3Writer.toString();
+
+            assertTrue(mergedContent.contains("ID1"));
+            assertTrue(mergedContent.contains("ID2"));
+            assertTrue(mergedContent.contains("feature1"));
+            assertTrue(mergedContent.contains("feature2"));
+        }
+    }
 }

--- a/src/test/resources/gff3toff_rules/resolution_directive.embl
+++ b/src/test/resources/gff3toff_rules/resolution_directive.embl
@@ -1,0 +1,27 @@
+ID   BN000065; SV 1; XXX; XXX; XXX; XXX; 0 BP.
+XX
+AC   BN000065;
+XX
+DE   .
+XX
+KW   .
+XX
+FH   Key             Location/Qualifiers
+FH
+FT   source          1..315242
+FT   gene            1..315242
+FT                   /gene="RHD"
+FT   gene            1..315242
+FT                   /gene="RHD2"
+FT   mRNA            133806..191728
+FT                   /gene="RHD"
+FT   mRNA            133806..191728
+FT                   /gene="RHD2"
+FT   rRNA            133970..145841
+FT                   /gene="RHD"
+FT                   /number=1
+FT   rRNA            133970..145841
+FT                   /gene="RHD2"
+FT                   /number=1
+XX
+//

--- a/src/test/resources/gff3toff_rules/resolution_directive.gff3
+++ b/src/test/resources/gff3toff_rules/resolution_directive.gff3
@@ -1,0 +1,9 @@
+##gff-version 3.1.26
+##sequence-region BN000065.1 1 315242
+BN000065.1	.	gene	1	315242	.	+	.	ID=gene_RHD;gene=RHD;
+BN000065.1	.	mRNA	133806	191728	.	+	.	Parent=gene_RHD;
+BN000065.1	.	rRNA	133970	145841	.	+	.	Parent=gene_RHD;number=1;
+###
+BN000065.1	.	gene	1	315242	.	+	.	ID=gene_RHD2;gene=RHD2;
+BN000065.1	.	mRNA	133806	191728	.	+	.	Parent=gene_RHD2;
+BN000065.1	.	rRNA	133970	145841	.	+	.	Parent=gene_RHD2;number=1;


### PR DESCRIPTION
This pull request addresses the conversion of GFF3 files containing multiple annotation blocks (separated by `###` directives) that correspond to a single accession. The EMBL Flat File format requires all features for a given accession to reside within one entry.

Changes include:
*   **`GFF3Annotation.java`**:
    *   Introduced a `merge` method to combine `GFF3Annotation` objects, facilitating the consolidation of features and directives.
    *   Implemented a `getAccession` method to accurately retrieve the accession, prioritizing the `##sequence-region` directive and falling back to the first feature's accession.
*   **`Gff3ToFFConverter.java`**:
    *   Modified the conversion logic to accumulate and merge `GFF3Annotation` objects that share the same accession. This ensures that all relevant features are grouped into a single EMBL entry during the conversion process.
*   **`GFF3AnnotationTest.java`**:
    *   Added new unit tests (`testMergeAnnotations` and `testGetAccession`) to validate the functionality of the new methods in `GFF3Annotation`.
*   **New Test Files**:
    *   `resolution_directive.gff3` and `resolution_directive.embl` were added to demonstrate and test the end-to-end conversion of GFF3 files with `###` directives into a single, correctly formatted EMBL entry.
