### PR TITLE
TTENA-185:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 base {
     archivesName = 'gff3tools'
     group = 'uk.ac.ebi.ena'
-    version = '4.1.2'
+    version = '4.2.0'
 }
 
 java {

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/translation/Translator.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/translation/Translator.java
@@ -131,7 +131,7 @@ public class Translator {
         threePrimePartial = firstFeature.isThreePrimePartial() || lastFeature.isThreePrimePartial();
     }
 
-    private static GFF3Feature getFirstFeature(List<GFF3Feature> features) throws IllegalArgumentException{
+    private static GFF3Feature getFirstFeature(List<GFF3Feature> features) {
         if (features == null || features.isEmpty()) {
             throw new IllegalArgumentException("features must not be null or empty");
         }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/translation/Translator.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/translation/Translator.java
@@ -86,9 +86,7 @@ public class Translator {
 
         feature = getFirstFeature(sortedFeatures);
 
-        fivePrimePartial = getCompoundFivePrimePartial(sortedFeatures);
-
-        threePrimePartial = getCompoundThreePrimePartial(sortedFeatures);
+        setCompoundPartiality(sortedFeatures);
 
         // TODO: Get translation table from taxon.
         int translationTable =
@@ -116,26 +114,18 @@ public class Translator {
         setPeptideFeature();
     }
 
-    private boolean getCompoundFivePrimePartial(List<GFF3Feature> features) {
+    private void setCompoundPartiality(List<GFF3Feature> features) {
         if (features.isEmpty()) {
-            return false;
+            fivePrimePartial = false;
+            threePrimePartial = false;
+            return;
         }
-        GFF3Feature firstFeature = features.get(0);
-        GFF3Feature lastFeature = features.get(features.size() - 1);
-        // return true if first location or last location is 5'.
-        // Both features are checked for 5' because partiality could be in complement strand.
-        return firstFeature.isFivePrimePartial() || lastFeature.isFivePrimePartial();
-    }
 
-    private boolean getCompoundThreePrimePartial(List<GFF3Feature> features) {
-        if (features.isEmpty()) {
-            return false;
-        }
         GFF3Feature firstFeature = features.get(0);
         GFF3Feature lastFeature = features.get(features.size() - 1);
-        // return true if first location or last location is 3'.
-        // Both features are checked for 3' because partiality could be in complement strand.
-        return firstFeature.isThreePrimePartial() || lastFeature.isThreePrimePartial();
+
+        fivePrimePartial = firstFeature.isFivePrimePartial() || lastFeature.isFivePrimePartial();
+        threePrimePartial = firstFeature.isThreePrimePartial() || lastFeature.isThreePrimePartial();
     }
 
     private static GFF3Feature getFirstFeature(List<GFF3Feature> features) {

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/translation/Translator.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/translation/Translator.java
@@ -76,20 +76,26 @@ public class Translator {
     private static final char START_CODON = 'M';
 
     /**
-     * Creates a new Translator with the specified translation table and GFF3 feature.
-     * If the feature has a "pseudo" or "pseudogene" attribute, the translator is set to non-translating mode.
+     * Creates a translator for one or more CDS sortedFeatures.
      *
-     * @param feature the GFF3 feature associated with this translation
-     * @throws TranslationException if the translation table is invalid
+     * <p>Shared translation metadata is taken from the first segment, while join-level
+     * partiality is derived across all sortedFeatures so compound CDS translation preserves
+     * existing 5'/3' partial boundaries.
      */
-    public Translator(GFF3Feature feature) throws TranslationException {
+    public Translator(List<GFF3Feature> sortedFeatures) throws TranslationException {
+
+        feature = getFirstFeature(sortedFeatures);
+
+        fivePrimePartial = getCompoundFivePrimePartial(sortedFeatures);
+
+        threePrimePartial = getCompoundThreePrimePartial(sortedFeatures);
 
         // TODO: Get translation table from taxon.
         int translationTable =
                 feature.getAttribute("transl_table").map(Integer::parseInt).orElse(DEFAULT_TRANSLATION_TABLE);
 
         this.codonTranslator = new CodonTranslator(translationTable);
-        this.feature = feature;
+
         if (feature.hasAttribute(GFF3Attributes.PSEUDO) || feature.hasAttribute(GFF3Attributes.PSEUDOGENE)) {
             this.nonTranslating = true;
         }
@@ -98,10 +104,6 @@ public class Translator {
             isComplement = true;
         }
 
-        fivePrimePartial = feature.isFivePrimePartial();
-
-        threePrimePartial = feature.isThreePrimePartial();
-
         codonStart = feature.getAttribute(GFF3Attributes.CODON_START)
                 .map(Integer::parseInt)
                 .orElse(codonStart);
@@ -109,10 +111,38 @@ public class Translator {
         // Parse transl_except attributes and add position exceptions
         handleTranslExceptAttributes(feature);
 
-        // Parse codon attributes and add codon exceptions
         handleCodonExceptAttributes(feature);
 
         setPeptideFeature();
+    }
+
+    private boolean getCompoundFivePrimePartial(List<GFF3Feature> features) {
+        if (features.isEmpty()) {
+            return false;
+        }
+        GFF3Feature firstFeature = features.get(0);
+        GFF3Feature lastFeature = features.get(features.size() - 1);
+        // return true if first location or last location is 5'.
+        // Both features are checked for 5' because partiality could be in complement strand.
+        return firstFeature.isFivePrimePartial() || lastFeature.isFivePrimePartial();
+    }
+
+    private boolean getCompoundThreePrimePartial(List<GFF3Feature> features) {
+        if (features.isEmpty()) {
+            return false;
+        }
+        GFF3Feature firstFeature = features.get(0);
+        GFF3Feature lastFeature = features.get(features.size() - 1);
+        // return true if first location or last location is 3'.
+        // Both features are checked for 3' because partiality could be in complement strand.
+        return firstFeature.isThreePrimePartial() || lastFeature.isThreePrimePartial();
+    }
+
+    private static GFF3Feature getFirstFeature(List<GFF3Feature> features) {
+        if (features == null || features.isEmpty()) {
+            throw new IllegalArgumentException("features must not be null or empty");
+        }
+        return features.get(0);
     }
 
     private void setPeptideFeature() {
@@ -263,10 +293,6 @@ public class Translator {
             }
 
             validateTranslation(translationResult);
-
-            if (translationResult.isFixedPseudo()) {
-                feature.addAttribute("pseudo", "true");
-            }
 
         } catch (TranslationException ex) {
             translationResult.addError(ex.getMessage());

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/translation/Translator.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/translation/Translator.java
@@ -109,6 +109,7 @@ public class Translator {
         // Parse transl_except attributes and add position exceptions
         handleTranslExceptAttributes(feature);
 
+        // Parse codon attributes and add codon exceptions
         handleCodonExceptAttributes(feature);
 
         setPeptideFeature();
@@ -124,11 +125,13 @@ public class Translator {
         GFF3Feature firstFeature = features.get(0);
         GFF3Feature lastFeature = features.get(features.size() - 1);
 
+        // Join-level partiality is determined from the boundary CDS segments.
+        // On complement joins, either boundary can carry the effective 5'/3' partial flag.
         fivePrimePartial = firstFeature.isFivePrimePartial() || lastFeature.isFivePrimePartial();
         threePrimePartial = firstFeature.isThreePrimePartial() || lastFeature.isThreePrimePartial();
     }
 
-    private static GFF3Feature getFirstFeature(List<GFF3Feature> features) {
+    private static GFF3Feature getFirstFeature(List<GFF3Feature> features) throws IllegalArgumentException{
         if (features == null || features.isEmpty()) {
             throw new IllegalArgumentException("features must not be null or empty");
         }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslationFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslationFix.java
@@ -99,23 +99,23 @@ public class TranslationFix {
         }
     }
 
-    private void translateCdsGroup(List<GFF3Feature> segments, SequenceLookup sequenceLookup, int line)
+    private void translateCdsGroup(List<GFF3Feature> features, SequenceLookup sequenceLookup, int line)
             throws ValidationException {
 
-        boolean isTransSpliced = segments.stream().anyMatch(s -> s.hasAttribute(GFF3Attributes.TRANS_SPLICING));
+        boolean isTransSpliced = features.stream().anyMatch(s -> s.hasAttribute(GFF3Attributes.TRANS_SPLICING));
 
-        List<GFF3Feature> sorted = new ArrayList<>(segments);
+        List<GFF3Feature> sortedFeatures = new ArrayList<>(features);
         if (!isTransSpliced) {
-            // Sort segments by genomic start position when they are not trans-spliced.
-            sorted.sort(Comparator.comparingLong(GFF3Feature::getStart));
+            // Sort features by genomic start position when they are not trans-spliced.
+            sortedFeatures.sort(Comparator.comparingLong(GFF3Feature::getStart));
         }
 
-        GFF3Feature representative = sorted.get(0);
+        GFF3Feature representative = sortedFeatures.get(0);
         String oldTranslation = lookupOldTranslation(representative);
 
         // Skip CDS features with exception attribute (e.g. ribosomal slippage).
-        // Check ALL segments — any segment carrying the exception applies to the whole join.
-        boolean hasException = sorted.stream()
+        // Check ALL sortedFeatures — any segment carrying the exception applies to the whole join.
+        boolean hasException = sortedFeatures.stream()
                 .anyMatch(s -> s.getAttribute(GFF3Attributes.EXCEPTION).isPresent());
         if (hasException) {
             // record the old translation as new translation in case of exception
@@ -124,15 +124,15 @@ public class TranslationFix {
         }
 
         try {
-            // Concatenate sequence slices from all segments in genomic order
+            // Concatenate sequence slices from all features in genomic order
             StringBuilder concatenated = new StringBuilder();
-            for (GFF3Feature segment : sorted) {
+            for (GFF3Feature segment : sortedFeatures) {
                 String slice =
                         sequenceLookup.getSequenceSlice(segment.accession(), segment.getStart(), segment.getEnd());
                 concatenated.append(slice);
             }
 
-            Translator translator = new Translator(representative);
+            Translator translator = new Translator(sortedFeatures);
             translator.enableAllFixes();
             TranslationResult result =
                     translator.translate(concatenated.toString().getBytes());
@@ -148,7 +148,7 @@ public class TranslationFix {
                 recordTranslationState(representative, line, oldTranslation, translation);
             }
 
-            propagateJoinAttributes(sorted, result);
+            propagateJoinAttributes(sortedFeatures, result);
         } catch (ValidationException e) {
             throw e;
         } catch (Exception e) {
@@ -188,13 +188,15 @@ public class TranslationFix {
             }
         }
 
-        // Propagate pseudo from the first CDS segment to all subsequent join segments.
-        first.getAttribute(GFF3Attributes.PSEUDO).ifPresent(pseudoValue -> {
-            for (int i = 1; i < segments.size(); i++) {
-                segments.get(i).removeAttributeList(GFF3Attributes.PSEUDO);
-                segments.get(i).addAttribute(GFF3Attributes.PSEUDO, pseudoValue);
+        // Only propagate pseudo when translation newly determines the CDS is pseudo.
+        // We intentionally do not copy an existing pseudo from the first segment to
+        // the rest of the group, because such segments should not be treated as one join.
+        if (result.isFixedPseudo()) {
+            for (GFF3Feature segment : segments) {
+                segment.removeAttributeList(GFF3Attributes.PSEUDO);
+                segment.addAttribute(GFF3Attributes.PSEUDO, "true");
             }
-        });
+        }
     }
 
     private String lookupOldTranslation(GFF3Feature feature) {

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/translation/TranslatorTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/translation/TranslatorTest.java
@@ -13,6 +13,7 @@ package uk.ac.ebi.embl.gff3tools.translation;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,11 @@ public class TranslatorTest {
     private Translator createTranslator(int table) throws TranslationException {
         GFF3Feature feature = createDefaultFeature();
         feature.addAttribute("transl_table", String.valueOf(table));
-        return new Translator(feature);
+        return createTranslator(feature);
+    }
+
+    private Translator createTranslator(GFF3Feature feature) throws TranslationException {
+        return new Translator(List.of(feature));
     }
 
     // ========== GFF3Feature Constructor Tests ==========
@@ -42,7 +47,7 @@ public class TranslatorTest {
         feature.addAttribute("pseudo", "true");
         feature.addAttribute("transl_table", "11");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         assertTrue(translator.isNonTranslating());
     }
 
@@ -53,7 +58,7 @@ public class TranslatorTest {
         feature.addAttribute("pseudogene", "processed");
         feature.addAttribute("transl_table", "11");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         assertTrue(translator.isNonTranslating());
     }
 
@@ -64,7 +69,7 @@ public class TranslatorTest {
         feature.addAttribute("product", "some protein");
         feature.addAttribute("transl_table", "11");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         assertFalse(translator.isNonTranslating());
     }
 
@@ -175,7 +180,7 @@ public class TranslatorTest {
         GFF3Feature feature = new GFF3Feature(
                 Optional.of("id1"), Optional.empty(), "seq1", Optional.empty(), "source", "CDS", 1, 100, ".", "+", "0");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         // ATG AAA AGT AAA TAG = M K S K *
         TranslationResult result = translator.translate("ATGAAAAGTAAATAG".getBytes());
         assertTrue(result.isValid());
@@ -183,7 +188,7 @@ public class TranslatorTest {
 
         // TAG is stop codon(*) at position 7-9 is replaced with -> W
         feature.addAttribute("transl_except", "(pos:7..9,aa:Trp)");
-        Translator translatorWithException = new Translator(feature);
+        Translator translatorWithException = createTranslator(feature);
         // ATG AAA AGT AAA TAG = M K W K *
         TranslationResult resultWithExp = translatorWithException.translate("ATGAAAAGTAAATAG".getBytes());
         assertTrue(resultWithExp.isValid());
@@ -198,7 +203,7 @@ public class TranslatorTest {
         // TAG is stop codon(*) at position 4-6 is replaced with -> U
         feature.addAttribute("transl_except", "(pos:4..6,aa:Sec)");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         // ATG TGA AAA TAG = M U K *
         TranslationResult result = translator.translate("ATGTGAAAATAG".getBytes());
         assertTrue(result.isValid());
@@ -213,7 +218,7 @@ public class TranslatorTest {
         feature.addAttribute("transl_except", "(pos:4..6,aa:Sec)");
         feature.addAttribute("transl_except", "(pos:7..9,aa:Trp)");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         // ATG TGA TGA AAA TAG = M U W K *
         TranslationResult result = translator.translate("ATGTGATGAAAATAG".getBytes());
         assertTrue(result.isValid());
@@ -227,7 +232,7 @@ public class TranslatorTest {
         // Make AAA at position 4-6 translate to stop (TERM)
         feature.addAttribute("transl_except", "(pos:4..6,aa:TERM)");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         // ATG AAA = M * (AAA becomes stop)
         TranslationResult result = translator.translate("ATGAAA".getBytes());
         assertTrue(result.isValid());
@@ -241,7 +246,7 @@ public class TranslatorTest {
         // TAG is stop codon at position 4-6, override to Pyrrolysine (O)
         feature.addAttribute("transl_except", "(pos:4..6,aa:Pyl)");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         // ATG TAG AAA TAG = M O K *
         TranslationResult result = translator.translate("ATGTAGAAATAG".getBytes());
         assertTrue(result.isValid());
@@ -265,7 +270,7 @@ public class TranslatorTest {
         // Lowercase amino acid name
         feature.addAttribute("transl_except", "(pos:4..6,aa:trp)");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         // ATG TGA AAA TAG = M W K * (TGA at 4-6 -> W)
         TranslationResult result = translator.translate("ATGTGAAAATAG".getBytes());
         assertTrue(result.isValid());
@@ -279,7 +284,7 @@ public class TranslatorTest {
         // Use TER (alternative to TERM) for stop codon
         feature.addAttribute("transl_except", "(pos:4..6,aa:Ter)");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         // ATG AAA = M * (AAA at 4-6 becomes stop)
         TranslationResult result = translator.translate("ATGAAA".getBytes());
         assertTrue(result.isValid());
@@ -293,7 +298,7 @@ public class TranslatorTest {
         // Flexible whitespace format
         feature.addAttribute("transl_except", "( pos : 4..6 , aa : Sec )");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         // ATG TGA AAA TAG = M U K *
         TranslationResult result = translator.translate("ATGTGAAAATAG".getBytes());
         assertTrue(result.isValid());
@@ -307,7 +312,7 @@ public class TranslatorTest {
         // OTHER amino acid -> X
         feature.addAttribute("transl_except", "(pos:4..6,aa:OTHER)");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         translator.setThreePrimePartial(true);
         // ATG AAA = M X (AAA at 4-6 becomes X)
         TranslationResult result = translator.translate("ATGAAA".getBytes());
@@ -322,7 +327,7 @@ public class TranslatorTest {
         // Unknown amino acid name
         feature.addAttribute("transl_except", "(pos:4..6,aa:Unknown)");
 
-        assertThrows(TranslationException.class, () -> new Translator(feature));
+        assertThrows(TranslationException.class, () -> createTranslator(feature));
     }
 
     @Test
@@ -332,7 +337,7 @@ public class TranslatorTest {
         // Invalid transl_except format
         feature.addAttribute("transl_except", "invalid_format");
 
-        assertThrows(TranslationException.class, () -> new Translator(feature));
+        assertThrows(TranslationException.class, () -> createTranslator(feature));
     }
 
     // ========== handleCodonExceptAttributes Tests ==========
@@ -343,7 +348,7 @@ public class TranslatorTest {
                 Optional.of("id1"), Optional.empty(), "seq1", Optional.empty(), "source", "CDS", 1, 100, ".", "+", "0");
 
         // Test without codon exception
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         TranslationResult result = translator.translate("ATGAAAAAATGA".getBytes());
         assertTrue(result.isValid());
         assertEquals("MKK", result.getConceptualTranslation());
@@ -351,7 +356,7 @@ public class TranslatorTest {
         // Test with codon exception
         // TGA normally is stop, make it tryptophan globally
         feature.addAttribute("codon", "(seq:\"aaa\",aa:Trp)");
-        Translator translatorWithExp = new Translator(feature);
+        Translator translatorWithExp = createTranslator(feature);
         // ATG AAA AAA TGA = M W W (all ATGs become W)
         TranslationResult resultWithExp = translatorWithExp.translate("ATGAAAAAATGA".getBytes());
         assertTrue(resultWithExp.isValid());
@@ -365,7 +370,7 @@ public class TranslatorTest {
         // TGA -> Selenocysteine globally
         feature.addAttribute("codon", "(seq:\"tga\",aa:Sec)");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         translator.setThreePrimePartial(true);
         // ATG TGA AAA = M U K
         TranslationResult result = translator.translate("ATGTGAAAA".getBytes());
@@ -381,7 +386,7 @@ public class TranslatorTest {
         feature.addAttribute("codon", "(seq:\"tga\",aa:Trp)");
         feature.addAttribute("codon", "(seq:\"tag\",aa:Pyl)");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         translator.setThreePrimePartial(true);
         // ATG TGA TAG = M W O (TGA->W, TAG->O)
         TranslationResult result = translator.translate("ATGTGATAG".getBytes());
@@ -396,7 +401,7 @@ public class TranslatorTest {
         // Unquoted codon format
         feature.addAttribute("codon", "(seq:tga,aa:Trp)");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         translator.setThreePrimePartial(true);
         TranslationResult result = translator.translate("ATGTGA".getBytes());
         assertTrue(result.isValid());
@@ -410,7 +415,7 @@ public class TranslatorTest {
         // Lowercase amino acid
         feature.addAttribute("codon", "(seq:\"tga\",aa:trp)");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         translator.setThreePrimePartial(true);
         TranslationResult result = translator.translate("ATGTGA".getBytes());
         assertTrue(result.isValid());
@@ -424,7 +429,7 @@ public class TranslatorTest {
         // Invalid codon format
         feature.addAttribute("codon", "invalid_format");
 
-        assertThrows(TranslationException.class, () -> new Translator(feature));
+        assertThrows(TranslationException.class, () -> createTranslator(feature));
     }
 
     @Test
@@ -434,7 +439,7 @@ public class TranslatorTest {
         // Unknown amino acid
         feature.addAttribute("codon", "(seq:\"tga\",aa:Unknown)");
 
-        assertThrows(TranslationException.class, () -> new Translator(feature));
+        assertThrows(TranslationException.class, () -> createTranslator(feature));
     }
 
     @Test
@@ -862,7 +867,7 @@ public class TranslatorTest {
                 Optional.of("id"), Optional.empty(), "seq", Optional.empty(), "source", "CDS", 1, 100, ".", "+", "0");
         feature.addAttribute("codon_start", "2");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
 
         assertEquals(2, translator.getCodonStart());
     }
@@ -873,7 +878,7 @@ public class TranslatorTest {
                 Optional.of("id"), Optional.empty(), "seq", Optional.empty(), "source", "CDS", 1, 100, ".", "+", "0");
         feature.addAttribute("codon_start", "3");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
 
         assertEquals(3, translator.getCodonStart());
     }
@@ -883,7 +888,7 @@ public class TranslatorTest {
         GFF3Feature feature = new GFF3Feature(
                 Optional.of("id"), Optional.empty(), "seq", Optional.empty(), "source", "CDS", 1, 100, ".", "+", "0");
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
 
         assertEquals(1, translator.getCodonStart());
     }
@@ -897,7 +902,7 @@ public class TranslatorTest {
         feature.addAttribute("codon_start", "2");
         feature.setFivePrimePartial();
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         translator.enableAllFixes();
         TranslationResult result = translator.translate("CATGAAATAA".getBytes());
 
@@ -928,7 +933,7 @@ public class TranslatorTest {
         FastaReader reader = new FastaReader(new File(
                 getClass().getClassLoader().getResource("translation/fasta.txt").getFile()));
 
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         translator.setThreePrimePartial(true);
         String sequence = reader.getSequenceSlice(0L, 4798, 5460).toUpperCase(Locale.ROOT);
 
@@ -964,7 +969,7 @@ public class TranslatorTest {
         // "MAAAVGRRACPAGRRSDAVIRVARSERLEMRHRSSWYASRPRGVCRLRVLLLVCAAVVPIVSSAPLPGYYCYAKNATERRTPNIDRDYWRPGVSVFGCRMPKGVCIEGEWTIEWYIPSLQASVINQVFFKSQTWLGPSMQYIIPSYERGKEVTCRQGFCVDRAEGNLIITDNNTRKEEWARKPTRDVVCKLTACLRATSVSPYSRTTYEECNGTLEDYLSLPDFENIYDISKVVPYVPPPKAPAVPPKVPGKAEDAPPDESCIGCDNPGLNAAAIAVPVVTVIVLVSGIGYLCRSTESRQRTLELYRDLWSSLRRRLHRGDYARDG";
         String expectedTranslation =
                 "MKRIGLERCFLSTSYRSTRFPSTALPRLTAERRSTFFTPDPKPRGGGCPANTPRVLYPPPHPGVRRAVKRLLPRNIRRRSRNARFTALRAGRRSSRKLHTLAGRLTPPSRGRGARPGG";
-        Translator translator = new Translator(feature);
+        Translator translator = createTranslator(feature);
         translator.setThreePrimePartial(true);
         // String sequence = reader.getSequenceSliceString(0L,999,1979).toUpperCase(Locale.ROOT);
         String sequence = reader.getSequenceSlice(0L, 480, 836).toUpperCase(Locale.ROOT);

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslationFixTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslationFixTest.java
@@ -146,6 +146,36 @@ class TranslationFixTest {
     }
 
     @Test
+    void preservesThreePrimePartialAcrossJoinDuringTranslation() throws Exception {
+        long seg1Start = 62703507L;
+        long seg1End = 62703686L;
+        long seg2Start = 62710877L;
+        long seg2End = 62710985L;
+
+        String seg1Sequence =
+                "TTGAAATGCTTGTGGGCTGGGCCAGTCTCACAGCAAGATTACAGAGTCATCTCTCTGCCATCTGATGAGAAGATACCTCAGGCACTGGAAAAAAACCCAGACTGTATGGTTCTTTTGGGATCCACTGCAGAGAATACTCCCAAGACAGAGAAGCATTCCGACCCTCCCAGTCCATCAGGA";
+        String seg2Sequence =
+                "CCTGAGGATAGCACAAGGCACTGCAGGAAGCAGGAGCACTTCACGGTACAGGGCCCTGCTCTTGGTGCTGCTGGGCCTCTTTGCAGGGAAGGGATAAAAATCCAGGGAC";
+
+        when(mockLookup.getSequenceSlice("seq1", seg1Start, seg1End)).thenReturn(seg1Sequence);
+        when(mockLookup.getSequenceSlice("seq1", seg2Start, seg2End)).thenReturn(seg2Sequence);
+
+        GFF3Feature seg1 = createFeature(OntologyTerm.CDS.name(), "cds1", "seq1", seg1Start, seg1End, "+");
+        GFF3Feature seg2 = createFeature(OntologyTerm.CDS.name(), "cds1", "seq1", seg2Start, seg2End, "+");
+        seg2.setThreePrimePartial();
+
+        GFF3Annotation annotation = createAnnotation(seg1, seg2);
+        fix.fixAnnotation(annotation, 1);
+
+        String key = TranslationState.buildKey(seg1.accession(), "cds1");
+        assertEquals(
+                "MKCLWAGPVSQQDYRVISLPSDEKIPQALEKNPDCMVLLGSTAENTPKTEKHSDPPSPSGPEDSTRHCRKQEHFTVQGPALGAAGPLCREGIKIQG",
+                translationState.get(key).newTranslation());
+        assertFalse(seg1.isFivePrimePartial(), "5' partial should not be introduced for an already 3'-partial join");
+        assertTrue(seg2.isThreePrimePartial(), "Existing 3' partial should be preserved on the last segment");
+    }
+
+    @Test
     void translatesMultiSegmentCdsComplementJoin() throws Exception {
         // seg1="TTATTT" (1-6), seg2="CAT" (10-12) → concat "TTATTTCAT" (9 bases)
         // Rev comp = "ATGAAATAA" → ATG=M, AAA=K, TAA=* → "MK"
@@ -186,20 +216,6 @@ class TranslationFixTest {
         assertFalse(seg1.hasAttribute("translation"));
         assertFalse(seg2.hasAttribute("translation"));
         verifyNoInteractions(mockLookup);
-    }
-
-    @Test
-    void propagatesPseudoToAllJoinSegments() throws Exception {
-        when(mockLookup.getSequenceSlice(any(), anyLong(), anyLong())).thenReturn("ATGAAATAA");
-
-        GFF3Feature seg1 = createFeature(OntologyTerm.CDS.name(), "cds1", "seq1", 1, 9, "+");
-        seg1.addAttribute("pseudo", "true");
-        GFF3Feature seg2 = createFeature(OntologyTerm.CDS.name(), "cds1", "seq1", 20, 28, "+");
-        GFF3Annotation annotation = createAnnotation(seg1, seg2);
-        fix.fixAnnotation(annotation, 1);
-
-        assertTrue(seg1.hasAttribute("pseudo"));
-        assertTrue(seg2.hasAttribute("pseudo"));
     }
 
     @Test


### PR DESCRIPTION
TO fix the translation-related issue:
This branch is now focused on the joined-CDS translation

- TranslatorTest.java now uses the list-based constructor consistently.
- TranslationFixTest.java adds the regression for preserving 3' partiality across a joined CDS translation and makes that test self-contained by embedding the exact sequence slices inline.
- The old test that expected pseudo to be copied from the first segment to the rest of the join was removed, matching your intended behavior.