### PR TITLE
Allow FileSequenceSource to accept a plain FastaHeaderSource

### DIFF
--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSource.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSource.java
@@ -20,6 +20,7 @@ import uk.ac.ebi.embl.fastareader.SequenceFileFormat;
 import uk.ac.ebi.embl.fastareader.api.SequenceFormatReader;
 import uk.ac.ebi.embl.fastareader.api.SequenceFormatReaderFactory;
 import uk.ac.ebi.embl.gff3tools.cli.SequenceFormat;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderSource;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.JsonHeaderParser;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.ParsedHeader;
@@ -38,6 +39,11 @@ import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.ParsedHeader;
  *
  * <p>For FASTA, it parses headers to extract submission IDs and maps them
  * to the library's ordinal IDs for sequence retrieval.
+ *
+ * <p>By default, FASTA headers are expected in the {@code >ID | JSON} format and are
+ * parsed by {@link JsonHeaderParser}. An optional {@link FastaHeaderSource} may be
+ * supplied instead; in that case the seqId is the plain first whitespace-delimited
+ * token after {@code >} and header metadata is resolved through the provided source.
  */
 @Slf4j
 public class FileSequenceSource implements SequenceSource {
@@ -58,6 +64,7 @@ public class FileSequenceSource implements SequenceSource {
     private final Map<String, Long> seqIdToOrdinal = new HashMap<>();
 
     private final Map<String, FastaHeader> seqIdToHeader = new HashMap<>();
+    private final FastaHeaderSource fastaHeaderSource;
     private boolean initialized;
 
     /**
@@ -68,17 +75,50 @@ public class FileSequenceSource implements SequenceSource {
      * @param sequenceKey optional key for plain sequences (GFF3 seqId); null to match any ID
      */
     public FileSequenceSource(Path path, SequenceFormat format, String sequenceKey) {
+        this(path, format, sequenceKey, null);
+    }
+
+    /**
+     * Creates a provider that will lazily open the sequence file on first access.
+     *
+     * <p>When {@code fastaHeaderSource} is non-null, FASTA headers are parsed using the
+     * plain first-token convention ({@code >seqId ...}) and header metadata is resolved
+     * through the supplied source instead of {@link JsonHeaderParser}.
+     *
+     * @param path path to the sequence file
+     * @param format the sequence format (fasta or plain)
+     * @param sequenceKey optional key for plain sequences (GFF3 seqId); null to match any ID
+     * @param fastaHeaderSource optional source for FASTA header metadata; null uses JSON parser
+     */
+    public FileSequenceSource(
+            Path path, SequenceFormat format, String sequenceKey, FastaHeaderSource fastaHeaderSource) {
         this.path = path;
         this.format = format;
         this.sequenceKey = sequenceKey;
+        this.fastaHeaderSource = fastaHeaderSource;
     }
 
     /** Convenience constructor for tests that supply a pre-opened reader. */
     public FileSequenceSource(SequenceFormatReader formatReader, SequenceFormat format, String sequenceKey) {
+        this(formatReader, format, sequenceKey, null);
+    }
+
+    /**
+     * Convenience constructor for tests that supply a pre-opened reader.
+     *
+     * <p>When {@code fastaHeaderSource} is non-null, FASTA headers are parsed using the
+     * plain first-token convention and header metadata is resolved through the supplied source.
+     */
+    public FileSequenceSource(
+            SequenceFormatReader formatReader,
+            SequenceFormat format,
+            String sequenceKey,
+            FastaHeaderSource fastaHeaderSource) {
         this.path = null;
         this.format = format;
         this.sequenceKey = sequenceKey;
         this.formatReader = formatReader;
+        this.fastaHeaderSource = fastaHeaderSource;
     }
 
     @Override
@@ -146,29 +186,82 @@ public class FileSequenceSource implements SequenceSource {
 
     private void buildIdMapping() {
         if (formatReader.getSequenceFileFormat() == SequenceFileFormat.FASTA) {
-            JsonHeaderParser headerParser = new JsonHeaderParser();
-            for (long ordinal : formatReader.getOrderedIds()) {
-                String headerLine = formatReader
-                        .getHeaderline(ordinal)
-                        .orElseThrow(() -> new RuntimeException("No header found for ordinal " + ordinal));
-                try {
-                    ParsedHeader parsed = headerParser.parse(headerLine);
-                    String submissionId = parsed.getId();
-                    if (seqIdToOrdinal.containsKey(submissionId)) {
-                        throw new RuntimeException("Duplicate submission ID in FASTA: " + submissionId);
-                    }
-                    seqIdToOrdinal.put(submissionId, ordinal);
-                    seqIdToHeader.put(submissionId, parsed.getHeader());
-                } catch (Exception e) {
-                    throw new RuntimeException(
-                            ("Failed to parse FASTA header at ordinal %d: %s. "
-                                            + "Expected format: >ID | {\"key\":\"value\",...}")
-                                    .formatted(ordinal, e.getMessage()),
-                            e);
-                }
+            if (fastaHeaderSource != null) {
+                buildIdMappingFromSource();
+            } else {
+                buildIdMappingFromJsonParser();
             }
         }
         // For plain sequences, no ID mapping needed — resolveOrdinal uses the single ordinal directly
+    }
+
+    /** Parses FASTA headers in {@code >ID | JSON} format using {@link JsonHeaderParser}. */
+    private void buildIdMappingFromJsonParser() {
+        JsonHeaderParser headerParser = new JsonHeaderParser();
+        for (long ordinal : formatReader.getOrderedIds()) {
+            String headerLine = formatReader
+                    .getHeaderline(ordinal)
+                    .orElseThrow(() -> new RuntimeException("No header found for ordinal " + ordinal));
+            try {
+                ParsedHeader parsed = headerParser.parse(headerLine);
+                String submissionId = parsed.getId();
+                if (seqIdToOrdinal.containsKey(submissionId)) {
+                    throw new RuntimeException("Duplicate submission ID in FASTA: " + submissionId);
+                }
+                seqIdToOrdinal.put(submissionId, ordinal);
+                seqIdToHeader.put(submissionId, parsed.getHeader());
+            } catch (Exception e) {
+                throw new RuntimeException(
+                        ("Failed to parse FASTA header at ordinal %d: %s. "
+                                        + "Expected format: >ID | {\"key\":\"value\",...}")
+                                .formatted(ordinal, e.getMessage()),
+                        e);
+            }
+        }
+    }
+
+    /**
+     * Resolves FASTA headers via the caller-supplied {@link FastaHeaderSource}.
+     *
+     * <p>The seqId is the plain first whitespace-delimited token after {@code >}.
+     * Sequences for which the source returns {@link java.util.Optional#empty()} are
+     * still registered in the ordinal map — they simply have no header entry.
+     */
+    private void buildIdMappingFromSource() {
+        for (long ordinal : formatReader.getOrderedIds()) {
+            String headerLine = formatReader
+                    .getHeaderline(ordinal)
+                    .orElseThrow(() -> new RuntimeException("No header found for ordinal " + ordinal));
+            String seqId = extractFirstToken(headerLine);
+            if (seqIdToOrdinal.containsKey(seqId)) {
+                throw new RuntimeException("Duplicate submission ID in FASTA: " + seqId);
+            }
+            seqIdToOrdinal.put(seqId, ordinal);
+            fastaHeaderSource.getHeader(seqId).ifPresent(h -> seqIdToHeader.put(seqId, h));
+        }
+    }
+
+    /**
+     * Extracts the first whitespace-delimited token from a FASTA header line,
+     * stripping the leading {@code >}.
+     *
+     * <p>Examples:
+     * <ul>
+     *   <li>{@code >chr1} → {@code chr1}</li>
+     *   <li>{@code >chr1 some description} → {@code chr1}</li>
+     *   <li>{@code >chr1\tmore info} → {@code chr1}</li>
+     * </ul>
+     */
+    static String extractFirstToken(String headerLine) {
+        String rest = headerLine.startsWith(">") ? headerLine.substring(1) : headerLine;
+        int end = rest.length();
+        for (int i = 0; i < rest.length(); i++) {
+            if (Character.isWhitespace(rest.charAt(i))) {
+                end = i;
+                break;
+            }
+        }
+        return rest.substring(0, end).trim();
     }
 
     private long resolveOrdinal(String seqId) {

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSource.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSource.java
@@ -109,7 +109,7 @@ public class FileSequenceSource implements SequenceSource {
      * <p>When {@code fastaHeaderSource} is non-null, FASTA headers are parsed using the
      * plain first-token convention and header metadata is resolved through the supplied source.
      */
-    public FileSequenceSource(
+    FileSequenceSource(
             SequenceFormatReader formatReader,
             SequenceFormat format,
             String sequenceKey,
@@ -232,12 +232,22 @@ public class FileSequenceSource implements SequenceSource {
             String headerLine = formatReader
                     .getHeaderline(ordinal)
                     .orElseThrow(() -> new RuntimeException("No header found for ordinal " + ordinal));
-            String seqId = extractFirstToken(headerLine);
-            if (seqIdToOrdinal.containsKey(seqId)) {
-                throw new RuntimeException("Duplicate submission ID in FASTA: " + seqId);
+            try {
+                String seqId = extractFirstToken(headerLine);
+                if (seqId.isEmpty()) {
+                    throw new RuntimeException("FASTA header has no id token. Header: " + headerLine);
+                }
+                if (seqIdToOrdinal.containsKey(seqId)) {
+                    throw new RuntimeException("Duplicate submission ID in FASTA: " + seqId);
+                }
+                seqIdToOrdinal.put(seqId, ordinal);
+                fastaHeaderSource.getHeader(seqId).ifPresent(h -> seqIdToHeader.put(seqId, h));
+            } catch (Exception e) {
+                throw new RuntimeException(
+                        "Failed to process FASTA header at ordinal %d: %s. Header: %s"
+                                .formatted(ordinal, e.getMessage(), headerLine),
+                        e);
             }
-            seqIdToOrdinal.put(seqId, ordinal);
-            fastaHeaderSource.getHeader(seqId).ifPresent(h -> seqIdToHeader.put(seqId, h));
         }
     }
 
@@ -261,7 +271,7 @@ public class FileSequenceSource implements SequenceSource {
                 break;
             }
         }
-        return rest.substring(0, end).trim();
+        return rest.substring(0, end);
     }
 
     private long resolveOrdinal(String seqId) {

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSourceTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSourceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import uk.ac.ebi.embl.fastareader.SequenceFileFormat;
 import uk.ac.ebi.embl.fastareader.api.SequenceFormatReader;
 import uk.ac.ebi.embl.gff3tools.cli.SequenceFormat;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderSource;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
 
 class FileSequenceSourceTest {
@@ -131,6 +132,117 @@ class FileSequenceSourceTest {
         SequenceFormatReader reader = mock(SequenceFormatReader.class);
         when(reader.getSequenceFileFormat()).thenReturn(SequenceFileFormat.PLAIN_SEQUENCE);
         when(reader.getOrderedIds()).thenReturn(List.of(0L));
+        return reader;
+    }
+
+    // -------------------------------------------------------------------------
+    // FastaHeaderSource path
+    // -------------------------------------------------------------------------
+
+    @Test
+    void hasSequence_withFastaHeaderSource_usesFirstToken() {
+        SequenceFormatReader mockReader = mockFastaReaderPlainHeaders("chr1", "chr2");
+        FastaHeaderSource source = seqId -> Optional.empty();
+
+        FileSequenceSource fss = new FileSequenceSource(mockReader, SequenceFormat.fasta, null, source);
+
+        assertTrue(fss.hasSequence("chr1"));
+        assertTrue(fss.hasSequence("chr2"));
+        assertFalse(fss.hasSequence("chr3"));
+    }
+
+    @Test
+    void hasSequence_withFastaHeaderSource_headerDescriptionOnly() {
+        // Header line has whitespace-separated description — only the first token is the seqId
+        SequenceFormatReader mockReader = mockFastaReaderPlainHeaders("scaffold_1");
+        FastaHeaderSource source = seqId -> Optional.empty();
+
+        FileSequenceSource fss = new FileSequenceSource(mockReader, SequenceFormat.fasta, null, source);
+
+        assertTrue(fss.hasSequence("scaffold_1"));
+        assertFalse(fss.hasSequence("scaffold_1 Homo sapiens chromosome 1"));
+    }
+
+    @Test
+    void getSeqIdToHeader_withFastaHeaderSource_populatesFromSource() {
+        SequenceFormatReader mockReader = mockFastaReaderPlainHeaders("seq1", "seq2");
+        FastaHeader expected = new FastaHeader();
+        expected.setDescription("from-source");
+        FastaHeaderSource source = seqId -> seqId.equals("seq1") ? Optional.of(expected) : Optional.empty();
+
+        FileSequenceSource fss = new FileSequenceSource(mockReader, SequenceFormat.fasta, null, source);
+        Map<String, FastaHeader> headers = fss.getSeqIdToHeader();
+
+        assertEquals(1, headers.size());
+        assertEquals("from-source", headers.get("seq1").getDescription());
+        assertFalse(headers.containsKey("seq2"));
+    }
+
+    @Test
+    void getSeqIdToHeader_withFastaHeaderSource_allEmptyOptionals_returnsEmptyMap() {
+        SequenceFormatReader mockReader = mockFastaReaderPlainHeaders("seq1");
+        FastaHeaderSource source = seqId -> Optional.empty();
+
+        FileSequenceSource fss = new FileSequenceSource(mockReader, SequenceFormat.fasta, null, source);
+
+        assertTrue(fss.getSeqIdToHeader().isEmpty());
+    }
+
+    @Test
+    void duplicateIds_withFastaHeaderSource_throwsRuntimeException() {
+        SequenceFormatReader mockReader = mock(SequenceFormatReader.class);
+        when(mockReader.getSequenceFileFormat()).thenReturn(SequenceFileFormat.FASTA);
+        when(mockReader.getOrderedIds()).thenReturn(List.of(0L, 1L));
+        when(mockReader.getHeaderline(0L)).thenReturn(Optional.of(">dup_id"));
+        when(mockReader.getHeaderline(1L)).thenReturn(Optional.of(">dup_id"));
+        FastaHeaderSource source = seqId -> Optional.empty();
+
+        FileSequenceSource fss = new FileSequenceSource(mockReader, SequenceFormat.fasta, null, source);
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> fss.hasSequence("dup_id"));
+        assertTrue(ex.getMessage().contains("Duplicate submission ID"));
+    }
+
+    // -------------------------------------------------------------------------
+    // extractFirstToken
+    // -------------------------------------------------------------------------
+
+    @Test
+    void extractFirstToken_noDescription() {
+        assertEquals("chr1", FileSequenceSource.extractFirstToken(">chr1"));
+    }
+
+    @Test
+    void extractFirstToken_spaceDescription() {
+        assertEquals("chr1", FileSequenceSource.extractFirstToken(">chr1 Homo sapiens chromosome 1"));
+    }
+
+    @Test
+    void extractFirstToken_tabDescription() {
+        assertEquals("scaffold_42", FileSequenceSource.extractFirstToken(">scaffold_42\tsome description"));
+    }
+
+    @Test
+    void extractFirstToken_noCaret() {
+        // Gracefully handles a line without the leading '>'
+        assertEquals("seq1", FileSequenceSource.extractFirstToken("seq1 description"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Creates a mock FASTA reader with plain headers like ">seqId description" for each ID. */
+    private SequenceFormatReader mockFastaReaderPlainHeaders(String... seqIds) {
+        SequenceFormatReader reader = mock(SequenceFormatReader.class);
+        when(reader.getSequenceFileFormat()).thenReturn(SequenceFileFormat.FASTA);
+        List<Long> ordinals = new java.util.ArrayList<>();
+        for (int i = 0; i < seqIds.length; i++) {
+            long ordinal = i;
+            ordinals.add(ordinal);
+            when(reader.getHeaderline(ordinal)).thenReturn(Optional.of(">" + seqIds[i] + " plain description"));
+        }
+        when(reader.getOrderedIds()).thenReturn(ordinals);
         return reader;
     }
 

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSourceTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSourceTest.java
@@ -189,6 +189,31 @@ class FileSequenceSourceTest {
     }
 
     @Test
+    void buildIdMappingFromSource_emptySeqIdThrowsRuntimeException() {
+        SequenceFormatReader mockReader = mock(SequenceFormatReader.class);
+        when(mockReader.getSequenceFileFormat()).thenReturn(SequenceFileFormat.FASTA);
+        when(mockReader.getOrderedIds()).thenReturn(List.of(0L));
+        when(mockReader.getHeaderline(0L)).thenReturn(Optional.of("> description with no id"));
+        FastaHeaderSource source = seqId -> Optional.empty();
+
+        FileSequenceSource fss = new FileSequenceSource(mockReader, SequenceFormat.fasta, null, source);
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> fss.hasSequence("x"));
+        assertTrue(ex.getMessage().contains("ordinal 0"));
+    }
+
+    @Test
+    void getSequenceSlice_withFastaHeaderSource_resolvesCorrectOrdinal() throws Exception {
+        SequenceFormatReader mockReader = mockFastaReaderPlainHeaders("chrA", "chrB");
+        when(mockReader.getSequenceSlice(1L, 1L, 5L)).thenReturn("ATGCC");
+        FastaHeaderSource source = seqId -> Optional.empty();
+
+        FileSequenceSource fss = new FileSequenceSource(mockReader, SequenceFormat.fasta, null, source);
+
+        assertEquals("ATGCC", fss.getSequenceSlice("chrB", 1L, 5L));
+    }
+
+    @Test
     void duplicateIds_withFastaHeaderSource_throwsRuntimeException() {
         SequenceFormatReader mockReader = mock(SequenceFormatReader.class);
         when(mockReader.getSequenceFileFormat()).thenReturn(SequenceFileFormat.FASTA);
@@ -226,6 +251,16 @@ class FileSequenceSourceTest {
     void extractFirstToken_noCaret() {
         // Gracefully handles a line without the leading '>'
         assertEquals("seq1", FileSequenceSource.extractFirstToken("seq1 description"));
+    }
+
+    @Test
+    void extractFirstToken_emptyAfterCaret() {
+        assertEquals("", FileSequenceSource.extractFirstToken(">"));
+    }
+
+    @Test
+    void extractFirstToken_onlyWhitespaceAfterCaret() {
+        assertEquals("", FileSequenceSource.extractFirstToken("> "));
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION


**Allow FileSequenceSource to accept a plain FastaHeaderSource**

Previously `FileSequenceSource` always parsed FASTA headers using `JsonHeaderParser`, which requires the proprietary `>ID | {JSON}` format. This made it impossible to use standard FASTA files (e.g. `>chr1 Homo sapiens chromosome 1`) without pre-converting headers.

## Changes

`FileSequenceSource` now accepts an optional `FastaHeaderSource` via new 4-arg constructors. When supplied:
- The seqId is extracted as the plain first whitespace-delimited token after `>`
- Header metadata is resolved through the provided source via `getHeader(seqId)`
- Empty tokens and exceptions from the source are reported with ordinal + header-line context, matching the error quality of the JSON path

When no `FastaHeaderSource` is supplied (`null`), behaviour is unchanged, `JsonHeaderParser` is used as before. All existing call-sites are unaffected.

