### PR TITLE
Support gzip-compressed sequence files in FileSequenceSource

### DIFF
--- a/src/main/java/uk/ac/ebi/embl/gff3tools/cli/FileConversionCommand.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/cli/FileConversionCommand.java
@@ -106,8 +106,6 @@ public class FileConversionCommand extends AbstractCommand {
         // Determine if we're writing to a file or stdout
         boolean writingToFile = !outputFilePath.toString().isEmpty();
         Path tempFile = null;
-        // Temporary decompressed copy of a gzipped FASTA input, if one is created below.
-        Path decompressedInput = null;
 
         try {
             // Write to a temp file first to ensure atomic output: if conversion fails,
@@ -143,12 +141,8 @@ public class FileConversionCommand extends AbstractCommand {
                     throw new CLIException("FASTA to GFF3 conversion requires FASTA input with sequence headers; "
                             + "plain sequence input (--sequence-format plain) has no sequence ID to emit.");
                 }
-                // fastareader cannot read gzip directly; decompress once to a temp file if needed.
-                Path sourcePath = decompressIfGzipped(inputFilePath);
-                if (!sourcePath.equals(inputFilePath)) {
-                    decompressedInput = sourcePath;
-                }
-                inputFastaSource = new FileSequenceSource(sourcePath, fmt, null);
+                // FileSequenceSource will decompress a gzipped input automatically.
+                inputFastaSource = new FileSequenceSource(inputFilePath, fmt, null);
                 sources.add(inputFastaSource);
             }
 
@@ -194,16 +188,6 @@ public class FileConversionCommand extends AbstractCommand {
                 }
             }
             throw new RuntimeException(e.getMessage(), e);
-        } finally {
-            // The engine (and its sequence source) is closed by now, so the decompressed copy
-            // is no longer in use and can be removed.
-            if (decompressedInput != null) {
-                try {
-                    Files.deleteIfExists(decompressedInput);
-                } catch (Exception deleteEx) {
-                    log.warn("Failed to delete temporary decompressed input: {}", decompressedInput);
-                }
-            }
         }
     }
 
@@ -228,38 +212,6 @@ public class FileConversionCommand extends AbstractCommand {
                 throw new CLIException("--linkage-evidence is only valid with --gap-type "
                         + "\"within scaffold\", \"repeat within scaffold\" or \"contamination\"");
             }
-        }
-    }
-
-    /**
-     * Returns the original path if the file is not gzip-compressed, otherwise decompresses it to a
-     * temporary file and returns that path. Used so {@code fastareader} (which cannot read gzip)
-     * can open a gzipped FASTA input.
-     */
-    private Path decompressIfGzipped(Path path) throws ReadException, NonExistingFile {
-        boolean gzipped;
-        try (InputStream peekStream = Files.newInputStream(path)) {
-            int byte1 = peekStream.read();
-            int byte2 = peekStream.read();
-            gzipped = (byte1 == GZIP_MAGIC_BYTE1 && byte2 == GZIP_MAGIC_BYTE2);
-        } catch (NoSuchFileException e) {
-            throw new NonExistingFile("The file does not exist: " + path, e);
-        } catch (IOException e) {
-            throw new ReadException("Error checking file format: " + path, e);
-        }
-
-        if (!gzipped) {
-            return path;
-        }
-
-        try {
-            Path tempFile = Files.createTempFile("gff3tools-fasta-", ".fasta");
-            try (InputStream gzipIn = new GZIPInputStream(Files.newInputStream(path))) {
-                Files.copy(gzipIn, tempFile, StandardCopyOption.REPLACE_EXISTING);
-            }
-            return tempFile;
-        } catch (IOException e) {
-            throw new ReadException("Failed to decompress gzipped FASTA: " + path, e);
         }
     }
 

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/cli/FileConversionCommand.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/cli/FileConversionCommand.java
@@ -15,7 +15,6 @@ import ch.qos.logback.classic.LoggerContext;
 import java.io.*;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
@@ -38,6 +37,7 @@ import uk.ac.ebi.embl.gff3tools.gff3toff.Gff3ToFFConverter;
 import uk.ac.ebi.embl.gff3tools.metadata.MasterMetadataProvider;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
 import uk.ac.ebi.embl.gff3tools.tsvconverter.TSVToGFF3Converter;
+import uk.ac.ebi.embl.gff3tools.utils.GzipUtils;
 import uk.ac.ebi.embl.gff3tools.validation.ValidationEngine;
 import uk.ac.ebi.embl.gff3tools.validation.meta.RuleSeverity;
 import uk.ac.ebi.embl.gff3tools.validation.provider.CompositeSequenceProvider;
@@ -47,9 +47,6 @@ import uk.ac.ebi.embl.gff3tools.validation.provider.FileSequenceSource;
 @CommandLine.Command(name = "conversion", description = "Performs format conversions to or from gff3")
 @Slf4j
 public class FileConversionCommand extends AbstractCommand {
-
-    private static final int GZIP_MAGIC_BYTE1 = 0x1f;
-    private static final int GZIP_MAGIC_BYTE2 = 0x8b;
 
     // INSDC gap types for which linkage_evidence is both required and allowed. Mirrors
     // AssemblyGapValidation; kept here only to fail fast with a clear usage message.
@@ -231,16 +228,7 @@ public class FileConversionCommand extends AbstractCommand {
             return new BufferedReader(new InputStreamReader(System.in));
         }
 
-        boolean gzipped;
-        try (InputStream peekStream = Files.newInputStream(inputFilePath)) {
-            int byte1 = peekStream.read();
-            int byte2 = peekStream.read();
-            gzipped = (byte1 == GZIP_MAGIC_BYTE1 && byte2 == GZIP_MAGIC_BYTE2);
-        } catch (NoSuchFileException e) {
-            throw new NonExistingFile("The file does not exist: " + inputFilePath, e);
-        } catch (IOException e) {
-            throw new ReadException("Error opening file: " + inputFilePath, e);
-        }
+        boolean gzipped = GzipUtils.isGzipped(inputFilePath);
 
         try {
             if (gzipped) {

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/utils/GzipUtils.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/utils/GzipUtils.java
@@ -51,7 +51,6 @@ public final class GzipUtils {
         Path tempFile = null;
         try {
             tempFile = Files.createTempFile(prefix, suffix);
-            tempFile.toFile().deleteOnExit();
             try (InputStream gzipIn = new GZIPInputStream(Files.newInputStream(source))) {
                 Files.copy(gzipIn, tempFile, StandardCopyOption.REPLACE_EXISTING);
             }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/utils/GzipUtils.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/utils/GzipUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.zip.GZIPInputStream;
+import uk.ac.ebi.embl.gff3tools.exception.NonExistingFile;
+import uk.ac.ebi.embl.gff3tools.exception.ReadException;
+
+/** Small helpers for gzip detection and decompression. */
+public final class GzipUtils {
+
+    private static final int GZIP_MAGIC_BYTE1 = 0x1f;
+    private static final int GZIP_MAGIC_BYTE2 = 0x8b;
+
+    private GzipUtils() {}
+
+    /** Returns {@code true} if the file starts with the gzip magic bytes. */
+    public static boolean isGzipped(Path path) throws NonExistingFile, ReadException {
+        try (InputStream peekStream = Files.newInputStream(path)) {
+            int byte1 = peekStream.read();
+            int byte2 = peekStream.read();
+            return byte1 == GZIP_MAGIC_BYTE1 && byte2 == GZIP_MAGIC_BYTE2;
+        } catch (NoSuchFileException e) {
+            throw new NonExistingFile("The file does not exist: " + path, e);
+        } catch (IOException e) {
+            throw new ReadException("Error checking file format: " + path, e);
+        }
+    }
+
+    /**
+     * Decompresses a gzip-compressed file to a temporary file.
+     *
+     * <p>The temporary file is registered with {@link File#deleteOnExit()} as a backstop so the
+     * JVM removes it on normal exit even if the caller's cleanup path is not reached.
+     */
+    public static Path decompressToTempFile(Path source, String prefix, String suffix) throws ReadException {
+        Path tempFile = null;
+        try {
+            tempFile = Files.createTempFile(prefix, suffix);
+            tempFile.toFile().deleteOnExit();
+            try (InputStream gzipIn = new GZIPInputStream(Files.newInputStream(source))) {
+                Files.copy(gzipIn, tempFile, StandardCopyOption.REPLACE_EXISTING);
+            }
+            return tempFile;
+        } catch (IOException e) {
+            if (tempFile != null) {
+                try {
+                    Files.deleteIfExists(tempFile);
+                } catch (IOException ignored) {
+                    // Best-effort cleanup; the original exception is what matters.
+                }
+            }
+            throw new ReadException("Failed to decompress gzipped file: " + source, e);
+        }
+    }
+}

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSource.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSource.java
@@ -10,16 +10,24 @@
  */
 package uk.ac.ebi.embl.gff3tools.validation.provider;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.zip.GZIPInputStream;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import uk.ac.ebi.embl.fastareader.SequenceFileFormat;
 import uk.ac.ebi.embl.fastareader.api.SequenceFormatReader;
 import uk.ac.ebi.embl.fastareader.api.SequenceFormatReaderFactory;
 import uk.ac.ebi.embl.gff3tools.cli.SequenceFormat;
+import uk.ac.ebi.embl.gff3tools.exception.NonExistingFile;
+import uk.ac.ebi.embl.gff3tools.exception.ReadException;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.JsonHeaderParser;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.ParsedHeader;
@@ -58,7 +66,19 @@ public class FileSequenceSource implements SequenceSource {
     private final Map<String, Long> seqIdToOrdinal = new HashMap<>();
 
     private final Map<String, FastaHeader> seqIdToHeader = new HashMap<>();
+    private volatile Path decompressedPath;
     private boolean initialized;
+
+    private static final int GZIP_MAGIC_BYTE1 = 0x1f;
+    private static final int GZIP_MAGIC_BYTE2 = 0x8b;
+
+    /**
+     * Returns the path to the temporary decompressed file, or null if the source
+     * was not gzipped. Exposed for tests only.
+     */
+    Path getDecompressedPathOrNull() {
+        return decompressedPath;
+    }
 
     /**
      * Creates a provider that will lazily open the sequence file on first access.
@@ -109,6 +129,13 @@ public class FileSequenceSource implements SequenceSource {
                 log.warn("Failed to close sequence reader: {}", e.getMessage());
             }
         }
+        if (decompressedPath != null) {
+            try {
+                Files.deleteIfExists(decompressedPath);
+            } catch (Exception e) {
+                log.warn("Failed to delete temporary decompressed sequence file: {}", e.getMessage());
+            }
+        }
     }
 
     /**
@@ -138,9 +165,60 @@ public class FileSequenceSource implements SequenceSource {
     }
 
     private SequenceFormatReader openReader() throws Exception {
+        Path filePath = resolvePath();
         return switch (format) {
-            case fasta -> SequenceFormatReaderFactory.readFasta(path.toFile());
-            case plain -> SequenceFormatReaderFactory.readPlainSequence(path.toFile());
+            case fasta -> SequenceFormatReaderFactory.readFasta(filePath.toFile());
+            case plain -> SequenceFormatReaderFactory.readPlainSequence(filePath.toFile());
+        };
+    }
+
+    private Path resolvePath() throws NonExistingFile, ReadException {
+        Path filePath = decompressIfGzipped(path);
+        if (!filePath.equals(path)) {
+            decompressedPath = filePath;
+        }
+        return filePath;
+    }
+
+    private Path decompressIfGzipped(Path filePath) throws NonExistingFile, ReadException {
+        boolean gzipped;
+        try (InputStream peekStream = Files.newInputStream(filePath)) {
+            int byte1 = peekStream.read();
+            int byte2 = peekStream.read();
+            gzipped = (byte1 == GZIP_MAGIC_BYTE1 && byte2 == GZIP_MAGIC_BYTE2);
+        } catch (NoSuchFileException e) {
+            throw new NonExistingFile("The sequence file does not exist: " + filePath, e);
+        } catch (IOException e) {
+            throw new ReadException("Error checking sequence file format: " + filePath, e);
+        }
+
+        if (!gzipped) {
+            return filePath;
+        }
+
+        Path tempFile = null;
+        try {
+            tempFile = Files.createTempFile("gff3tools-sequence-", getFormatSuffix(format));
+            try (InputStream gzipIn = new GZIPInputStream(Files.newInputStream(filePath))) {
+                Files.copy(gzipIn, tempFile, StandardCopyOption.REPLACE_EXISTING);
+            }
+            return tempFile;
+        } catch (IOException e) {
+            if (tempFile != null) {
+                try {
+                    Files.deleteIfExists(tempFile);
+                } catch (IOException ignored) {
+                    // Best-effort cleanup; the original exception is what matters.
+                }
+            }
+            throw new ReadException("Failed to decompress gzipped sequence file: " + filePath, e);
+        }
+    }
+
+    private static String getFormatSuffix(SequenceFormat format) {
+        return switch (format) {
+            case fasta -> ".fasta";
+            case plain -> ".seq";
         };
     }
 

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSource.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSource.java
@@ -10,16 +10,11 @@
  */
 package uk.ac.ebi.embl.gff3tools.validation.provider;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.zip.GZIPInputStream;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import uk.ac.ebi.embl.fastareader.SequenceFileFormat;
@@ -31,6 +26,7 @@ import uk.ac.ebi.embl.gff3tools.exception.ReadException;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.JsonHeaderParser;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.ParsedHeader;
+import uk.ac.ebi.embl.gff3tools.utils.GzipUtils;
 
 /**
  * A {@link SequenceSource} backed by a single file (FASTA or plain sequence).
@@ -68,9 +64,6 @@ public class FileSequenceSource implements SequenceSource {
     private final Map<String, FastaHeader> seqIdToHeader = new HashMap<>();
     private volatile Path decompressedPath;
     private boolean initialized;
-
-    private static final int GZIP_MAGIC_BYTE1 = 0x1f;
-    private static final int GZIP_MAGIC_BYTE2 = 0x8b;
 
     /**
      * Returns the path to the temporary decompressed file, or null if the source
@@ -181,38 +174,10 @@ public class FileSequenceSource implements SequenceSource {
     }
 
     private Path decompressIfGzipped(Path filePath) throws NonExistingFile, ReadException {
-        boolean gzipped;
-        try (InputStream peekStream = Files.newInputStream(filePath)) {
-            int byte1 = peekStream.read();
-            int byte2 = peekStream.read();
-            gzipped = (byte1 == GZIP_MAGIC_BYTE1 && byte2 == GZIP_MAGIC_BYTE2);
-        } catch (NoSuchFileException e) {
-            throw new NonExistingFile("The sequence file does not exist: " + filePath, e);
-        } catch (IOException e) {
-            throw new ReadException("Error checking sequence file format: " + filePath, e);
-        }
-
-        if (!gzipped) {
+        if (!GzipUtils.isGzipped(filePath)) {
             return filePath;
         }
-
-        Path tempFile = null;
-        try {
-            tempFile = Files.createTempFile("gff3tools-sequence-", getFormatSuffix(format));
-            try (InputStream gzipIn = new GZIPInputStream(Files.newInputStream(filePath))) {
-                Files.copy(gzipIn, tempFile, StandardCopyOption.REPLACE_EXISTING);
-            }
-            return tempFile;
-        } catch (IOException e) {
-            if (tempFile != null) {
-                try {
-                    Files.deleteIfExists(tempFile);
-                } catch (IOException ignored) {
-                    // Best-effort cleanup; the original exception is what matters.
-                }
-            }
-            throw new ReadException("Failed to decompress gzipped sequence file: " + filePath, e);
-        }
+        return GzipUtils.decompressToTempFile(filePath, "gff3tools-sequence-", getFormatSuffix(format));
     }
 
     private static String getFormatSuffix(SequenceFormat format) {

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSource.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSource.java
@@ -62,16 +62,11 @@ public class FileSequenceSource implements SequenceSource {
     private final Map<String, Long> seqIdToOrdinal = new HashMap<>();
 
     private final Map<String, FastaHeader> seqIdToHeader = new HashMap<>();
-    private volatile Path decompressedPath;
-    private boolean initialized;
 
-    /**
-     * Returns the path to the temporary decompressed file, or null if the source
-     * was not gzipped. Exposed for tests only.
-     */
-    Path getDecompressedPathOrNull() {
-        return decompressedPath;
-    }
+    @Getter
+    private volatile Path decompressedPath;
+
+    private boolean initialized;
 
     /**
      * Creates a provider that will lazily open the sequence file on first access.
@@ -166,6 +161,9 @@ public class FileSequenceSource implements SequenceSource {
     }
 
     private Path resolvePath() throws NonExistingFile, ReadException {
+        if (decompressedPath != null) {
+            return decompressedPath;
+        }
         Path filePath = decompressIfGzipped(path);
         if (!filePath.equals(path)) {
             decompressedPath = filePath;

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSourceTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSourceTest.java
@@ -113,13 +113,12 @@ class FileSequenceSourceTest {
         FileSequenceSource source = new FileSequenceSource(gzippedFasta, SequenceFormat.fasta, null);
 
         assertTrue(source.hasSequence("seq1"));
-        assertNotNull(source.getDecompressedPathOrNull(), "A gzipped file should be decompressed to a temp file");
+        assertNotNull(source.getDecompressedPath(), "A gzipped file should be decompressed to a temp file");
         assertEquals("ACGT", source.getSequenceSlice("seq1", 1L, 4L));
 
         source.close();
         assertFalse(
-                Files.exists(source.getDecompressedPathOrNull()),
-                "Temporary decompressed file should be deleted on close");
+                Files.exists(source.getDecompressedPath()), "Temporary decompressed file should be deleted on close");
     }
 
     @Test
@@ -128,11 +127,11 @@ class FileSequenceSourceTest {
         FileSequenceSource source = new FileSequenceSource(gzippedSeq, SequenceFormat.plain, null);
 
         assertTrue(source.hasSequence("any-id"));
-        assertNotNull(source.getDecompressedPathOrNull());
+        assertNotNull(source.getDecompressedPath());
         assertEquals("ACGT", source.getSequenceSlice("any-id", 1L, 4L));
 
         source.close();
-        assertFalse(Files.exists(source.getDecompressedPathOrNull()));
+        assertFalse(Files.exists(source.getDecompressedPath()));
     }
 
     @Test
@@ -141,7 +140,7 @@ class FileSequenceSourceTest {
         FileSequenceSource source = new FileSequenceSource(fasta, SequenceFormat.fasta, null);
 
         assertTrue(source.hasSequence("seq1"));
-        assertNull(source.getDecompressedPathOrNull(), "No temp file should be created for an uncompressed file");
+        assertNull(source.getDecompressedPath(), "No temp file should be created for an uncompressed file");
         assertEquals("ACGT", source.getSequenceSlice("seq1", 1L, 4L));
 
         source.close();
@@ -155,7 +154,7 @@ class FileSequenceSourceTest {
 
         RuntimeException ex = assertThrows(RuntimeException.class, () -> source.hasSequence("seq1"));
         assertTrue(ex.getMessage().contains("Failed to open sequence file"));
-        assertNull(source.getDecompressedPathOrNull(), "No decompressed path should be recorded on failure");
+        assertNull(source.getDecompressedPath(), "No decompressed path should be recorded on failure");
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSourceTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSourceTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -141,8 +142,20 @@ class FileSequenceSourceTest {
 
         assertTrue(source.hasSequence("seq1"));
         assertNull(source.getDecompressedPathOrNull(), "No temp file should be created for an uncompressed file");
+        assertEquals("ACGT", source.getSequenceSlice("seq1", 1L, 4L));
 
         source.close();
+    }
+
+    @Test
+    void corruptGzipDoesNotCreateDecompressedFile() throws Exception {
+        Path corruptGz = tempDir.resolve("corrupt.gz");
+        Files.write(corruptGz, new byte[] {0x1f, (byte) 0x8b, 0x00, 0x00});
+        FileSequenceSource source = new FileSequenceSource(corruptGz, SequenceFormat.fasta, null);
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> source.hasSequence("seq1"));
+        assertTrue(ex.getMessage().contains("Failed to open sequence file"));
+        assertNull(source.getDecompressedPathOrNull(), "No decompressed path should be recorded on failure");
     }
 
     @Test
@@ -200,7 +213,7 @@ class FileSequenceSourceTest {
     private Path gzipToTempFile(String content) throws IOException {
         Path tempFile = tempDir.resolve("test-%d.gz".formatted(System.nanoTime()));
         try (GZIPOutputStream gzipOut = new GZIPOutputStream(Files.newOutputStream(tempFile))) {
-            gzipOut.write(content.getBytes());
+            gzipOut.write(content.getBytes(StandardCharsets.UTF_8));
         }
         return tempFile;
     }

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSourceTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/provider/FileSequenceSourceTest.java
@@ -13,16 +13,24 @@ package uk.ac.ebi.embl.gff3tools.validation.provider;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.zip.GZIPOutputStream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import uk.ac.ebi.embl.fastareader.SequenceFileFormat;
 import uk.ac.ebi.embl.fastareader.api.SequenceFormatReader;
 import uk.ac.ebi.embl.gff3tools.cli.SequenceFormat;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
 
 class FileSequenceSourceTest {
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void hasSequenceReturnsTrueForPlainSequenceAnyId_noKey() {
@@ -99,6 +107,45 @@ class FileSequenceSourceTest {
     }
 
     @Test
+    void canReadGzippedFastaFile() throws Exception {
+        Path gzippedFasta = gzipToTempFile(">seq1 | {\"description\":\"test\"}\nACGT\n");
+        FileSequenceSource source = new FileSequenceSource(gzippedFasta, SequenceFormat.fasta, null);
+
+        assertTrue(source.hasSequence("seq1"));
+        assertNotNull(source.getDecompressedPathOrNull(), "A gzipped file should be decompressed to a temp file");
+        assertEquals("ACGT", source.getSequenceSlice("seq1", 1L, 4L));
+
+        source.close();
+        assertFalse(
+                Files.exists(source.getDecompressedPathOrNull()),
+                "Temporary decompressed file should be deleted on close");
+    }
+
+    @Test
+    void canReadGzippedPlainSequenceFile() throws Exception {
+        Path gzippedSeq = gzipToTempFile("ACGTACGT");
+        FileSequenceSource source = new FileSequenceSource(gzippedSeq, SequenceFormat.plain, null);
+
+        assertTrue(source.hasSequence("any-id"));
+        assertNotNull(source.getDecompressedPathOrNull());
+        assertEquals("ACGT", source.getSequenceSlice("any-id", 1L, 4L));
+
+        source.close();
+        assertFalse(Files.exists(source.getDecompressedPathOrNull()));
+    }
+
+    @Test
+    void nonGzippedFileStillWorks() throws Exception {
+        Path fasta = Files.writeString(tempDir.resolve("plain.fasta"), ">seq1 | {\"description\":\"test\"}\nACGT\n");
+        FileSequenceSource source = new FileSequenceSource(fasta, SequenceFormat.fasta, null);
+
+        assertTrue(source.hasSequence("seq1"));
+        assertNull(source.getDecompressedPathOrNull(), "No temp file should be created for an uncompressed file");
+
+        source.close();
+    }
+
+    @Test
     void getSeqIdToHeaderReturnsPopulatedMapForFasta() {
         SequenceFormatReader mockReader = mockFastaReader("seq1", "seq2");
         FileSequenceSource source = new FileSequenceSource(mockReader, SequenceFormat.fasta, null);
@@ -148,5 +195,13 @@ class FileSequenceSourceTest {
         }
         when(reader.getOrderedIds()).thenReturn(ordinals);
         return reader;
+    }
+
+    private Path gzipToTempFile(String content) throws IOException {
+        Path tempFile = tempDir.resolve("test-%d.gz".formatted(System.nanoTime()));
+        try (GZIPOutputStream gzipOut = new GZIPOutputStream(Files.newOutputStream(tempFile))) {
+            gzipOut.write(content.getBytes());
+        }
+        return tempFile;
     }
 }


### PR DESCRIPTION

### What changed
- `FileSequenceSource` now transparently detects and decompresses `.gz` FASTA and plain sequence files to a temporary file before passing them to the `fastareader`.
- Added `GzipUtils` to share gzip detection and decompression logic between `FileSequenceSource` and `FileConversionCommand`.
- Removed the duplicate decompression logic in `FileConversionCommand` for the FASTA→GFF3 path; it now relies on `FileSequenceSource`.
- Temporary decompressed files are:
  - deleted deterministically in `FileSequenceSource.close()`,
  - registered with `deleteOnExit()` as a backstop if `close()` is not reached.
- Added tests for:
  - gzipped FASTA,
  - gzipped plain sequence,
  - uncompressed FASTA still working,
  - corrupt gzip failing cleanly without leaking a temp file.

### Why
The sequence provider (`--sequence`) previously failed on gzip-compressed FASTA files because the underlying `fastareader` library cannot read gzip directly. Users had to decompress files manually before running the tool.
