### PR TITLE
Ttena 258 fastaheader fixes and moved validations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 base {
     archivesName = 'gff3tools'
     group = 'uk.ac.ebi.ena'
-    version = '4.7.2'
+    version = '4.7.3'
 }
 
 java {

--- a/docs/2607071200_effective_metadata_resolution.md
+++ b/docs/2607071200_effective_metadata_resolution.md
@@ -1,0 +1,237 @@
+- Feature Name: `effective_metadata_resolution`
+- Document Date: 2026-07-07
+- Last Updated: 2026-07-07
+
+# Summary
+
+During GFF3-to-EMBL conversion, sequence-level metadata (description, molecule type,
+topology, chromosome name/type/location, taxonomy, etc.) can arrive from two independent
+sources in the *same* run: a master-entry file (`--master-entry`, exposed via
+`MasterMetadataProvider`) and FASTA headers (`--fasta-header` or FASTA-embedded, exposed via
+`FastaHeaderProvider`). This design introduces a single **effective-metadata resolution** step
+that merges both sources — with a well-defined precedence — into one resolved object per
+accession, validates and normalises *that* object once, and feeds it to `GFF3Mapper`. It
+replaces the current arrangement where the precedence is implicit in `GFF3Mapper`'s method
+ordering and where the master-entry path is not validated at all.
+
+# Motivation & Rationale
+
+## Problems with the current design
+
+1. **Implicit, duplicated precedence.** `GFF3Mapper.mapGFF3ToEntry` calls
+   `applyMasterMetadata(...)` then `applyFastaHeader(...)`. Master wins purely because it runs
+   first, and the header "fills the gaps" via scattered guards such as
+   `if (sourceFt.getQualifiers("organelle").isEmpty())` and `if (!hasChromosomeQualifier(...))`.
+   The precedence rule is not stated in one place and is easy to break.
+
+2. **The master-entry path has no validation or normalisation.** The FASTA-header path is
+   covered by `FastaHeaderFormatValidation` and `FastaHeaderNormalisationFix`; `MasterMetadata`
+   (deserialised straight from MasterEntry JSON in `MasterEntryJsonMetadataSource`) is mapped
+   verbatim, so its chromosome fields are neither validated nor canonicalised.
+
+3. **Silent cross-source fall-through.** Because the mapper warn-skips an unrecognised master
+   `chromosome_location` (leaving no `/organelle` qualifier), the header path — which only fires
+   when that qualifier slot is still empty — can silently supply its own value, overriding what
+   the master file actually specified. Validating each source independently would not catch
+   this, because neither source in isolation is wrong.
+
+## Rationale for the chosen approach
+
+Resolving both sources into one *effective* view before validation means validation sees
+exactly what the mapper will emit, the precedence rule lives in exactly one place, and both
+sources are covered by the same rules with no duplication. It aligns with the project direction
+of this tool owning validation rather than deferring to downstream EMBL validation.
+
+## Team decision on `chromosome_location` (2026-07)
+
+After discussion with the team, **`chromosome_location` is a mandatory attribute** when a
+chromosome is described (i.e. whenever `chromosome_name` and `chromosome_type` are present),
+rather than optional-with-an-implied-nuclear-default. To keep the nuclear/cytoplasmic default
+expressible, **`Nuclear` is supported as an allowed value** of the controlled vocabulary. This
+supersedes the interim change on branch `TTENA-258-fastaheader-fixes-and-moved-validations`
+(commit `cdd6822`) that had made `chromosome_location` optional and stripped a submitted
+`"nuclear"` to absent; that approach is reverted in favour of the mandatory + explicit-`Nuclear`
+model described here.
+
+# Usage Guidelines
+
+- Supply metadata via `--master-entry` and/or `--fasta-header` (and/or FASTA-embedded headers)
+  exactly as today; no CLI change.
+- **Precedence:** for any field, the master-entry value wins; the FASTA header fills a field
+  only when the master value is absent/blank. This is unchanged in spirit from today, but is now
+  enforced in one place (`MetadataResolver`).
+- **Chromosome fields (per team decision):**
+  - Allowed combinations: *none* (unplaced contig), *chromosome_name only* (unlocalised), or
+    *chromosome_name + chromosome_type + chromosome_location* (chromosome).
+  - `chromosome_location` is mandatory for the chromosome combination; use `Nuclear` for a
+    chromosome residing in the nucleus (or cytoplasm for prokaryotes). Organelle chromosomes use
+    the INSDC `/organelle` values (`Mitochondrion`, `Chloroplast`, …).
+- **Extending vocabularies:** add values to `ControlledVocabularyUtils.ChromosomeLocation`
+  (canonical casing as the enum value). `Nuclear` is a gff3tools extension of the INSDC
+  `/organelle` list; it maps to *no* `/organelle` qualifier in EMBL output.
+
+# System Overview / High-Level Design
+
+New/changed concepts:
+
+- **`ResolvedMetadata`** — the effective, merged metadata for a single accession. Either a new
+  lean type or a reuse of `MasterMetadata` (already documented as "the union of all metadata
+  fields needed by both conversion directions").
+- **`MetadataResolver`** — merges a `MasterMetadata` (from `MasterMetadataProvider`) and a
+  `FastaHeader` (from `FastaHeaderProvider`) into a `ResolvedMetadata`, encoding the
+  master-wins / header-fills-gaps precedence in one place.
+- **`ChromosomeFields`** — a small value type `(name, type, location)` carrying the shared
+  chromosome combination + vocabulary rules, decoupled from any provider so both the
+  FASTA-header path and the merged path use identical logic.
+- **`MetadataNormalisationFix` / `MetadataFormatValidation`** — engine-registered fix and
+  validation that operate on the *resolved* view (superseding, or delegating from, the
+  FASTA-header-specific `FastaHeaderNormalisationFix` / `FastaHeaderFormatValidation`).
+
+Data flow:
+
+```
+                 ┌─ MasterMetadataProvider.getMetadata(acc) ─┐
+MetadataResolver ┤                                           ├─► ResolvedMetadata (precedence explicit)
+                 └─ FastaHeaderProvider.getHeader(acc)       ─┘
+                                    │
+             MetadataNormalisationFix   (ChromosomeFields.normalised(): ascii-fold, canonicalise vocab)
+                                    │
+             MetadataFormatValidation   (ChromosomeFields.validate(): combination + vocabulary + mandatory location)
+                                    │
+             GFF3Mapper.applyMetadata(resolved)   (single mapping path, no implicit precedence)
+```
+
+Integration: `GFF3Mapper.mapGFF3ToEntry` replaces the `applyMasterMetadata` + `applyFastaHeader`
+pair with a single `applyMetadata(resolved)`.
+
+# Detailed Design & Implementation
+
+## `ChromosomeFields` (shared rules)
+
+```java
+public record ChromosomeFields(String name, String type, String location) {
+
+    /** ascii-fold + canonicalise vocabulary values to their controlled form. */
+    public ChromosomeFields normalised() { ... }
+
+    /**
+     * Combination + vocabulary rules. Per the 2026-07 team decision, chromosome_location is
+     * mandatory whenever a chromosome is described. Valid combinations:
+     *   - none
+     *   - name only                    (unlocalised)
+     *   - name + type + location       (chromosome)
+     * Equivalently: type OR location present => all three must be present.
+     */
+    public List<String> validate() { ... }
+}
+```
+
+`ControlledVocabularyUtils.ChromosomeLocation` keeps the 18 INSDC `/organelle` values **plus**
+`NUCLEAR("Nuclear")`, documented as a gff3tools extension that maps to no `/organelle`
+qualifier.
+
+## `MetadataResolver`
+
+```java
+public static Optional<ResolvedMetadata> resolve(
+        String accession, MasterMetadataProvider master, FastaHeaderProvider header) {
+    var m = master == null ? Optional.<MasterMetadata>empty() : master.getMetadata(accession);
+    var h = header == null ? Optional.<FastaHeader>empty()    : header.getHeader(accession);
+    if (m.isEmpty() && h.isEmpty()) return Optional.empty();
+
+    // master wins; header fills gaps — the ONE place this rule lives
+    return Optional.of(ResolvedMetadata.builder()
+        .description(firstNonBlank(m.map(MasterMetadata::getDescription),  h.map(FastaHeader::getDescription)))
+        .moleculeType(firstNonBlank(m.map(MasterMetadata::getMoleculeType), h.map(FastaHeader::getMoleculeType)))
+        .topology(firstNonBlank(m.map(MasterMetadata::getTopology),         h.map(FastaHeader::getTopology)))
+        .chromosome(new ChromosomeFields(
+            firstNonBlank(m.map(MasterMetadata::getChromosomeName),     h.map(FastaHeader::getChromosomeName)),
+            firstNonBlank(m.map(MasterMetadata::getChromosomeType),     h.map(FastaHeader::getChromosomeType)),
+            firstNonBlank(m.map(MasterMetadata::getChromosomeLocation), h.map(FastaHeader::getChromosomeLocation))))
+        // ...taxonomy, WGS, dates, cross-references, etc.
+        .build());
+}
+```
+
+## `GFF3Mapper`
+
+`applyMasterMetadata(...)` + `applyFastaHeader(...)` collapse into:
+
+```java
+private void applyMetadata(GFF3SequenceRegion region, Entry entry, Sequence seq, SourceFeature src) {
+    if (region == null) return;
+    MetadataResolver.resolve(region.accessionId(), metadataProvider, headerProvider)
+        .ifPresent(rm -> {
+            mapChromosome(rm.chromosome(), src);   // fields already validated + normalised
+            mapTopology(rm.topology(), seq);
+            // ...description, mol_type, taxonomy, WGS, dates...
+        });
+}
+```
+
+`mapChromosomeLocation` keeps mapping `Nuclear` (case-insensitively) to no `/organelle`
+qualifier; all other values resolve via the controlled vocabulary, and an unrecognised value is
+rejected rather than passed through.
+
+## Corner cases
+
+- **Both sources present, same field:** master value used; header ignored for that field.
+- **Master present but invalid `chromosome_location`:** now caught by `MetadataFormatValidation`
+  on the resolved view (a `ValidationException`), instead of being silently warn-skipped and
+  back-filled by the header.
+- **Neither source:** resolver returns empty; mapping is a no-op, as today.
+- **`MasterMetadataProvider` internal ordering** ("first source wins, no field merging" between
+  master sources) is unchanged; the new merge is only master-vs-header.
+
+# Alternatives Considered
+
+- **Option 1 — validate/normalise each source independently against shared rules.** Cheaper and
+  closes the "no validation on master" gap, but does not address the silent cross-source
+  fall-through, because neither source is individually wrong. Rejected as insufficient given both
+  sources routinely coexist.
+- **`chromosome_location` optional with implied nuclear default** (interim commit `cdd6822`).
+  Faithful to the ENA "optional fourth column" wording, but leaves the nuclear case implicit and
+  under-specified. Superseded by the team decision to make the attribute mandatory with explicit
+  `Nuclear`.
+- **Full unification of the two providers into one metadata model.** Larger refactor of the
+  provider chain; deferred — the resolver captures the merge without forcing the providers to
+  merge upstream.
+
+# Technical Debt / Future Considerations
+
+- Staged migration recommended: (1) introduce `ChromosomeFields` + `MetadataResolver` as pure,
+  well-tested units with no behaviour change; (2) switch `GFF3Mapper` to `applyMetadata`;
+  (3) move validation/normalisation onto the resolved view and retire the FASTA-header-specific
+  classes (or make them thin delegates).
+- `EmblEntryMetadataSource` (FF→GFF3 direction) does not currently populate chromosome fields;
+  out of scope here.
+- Consider whether `MetadataFormatValidation` should aggregate errors across all metadata fields
+  (topology, mol_type, chromosome) in one pass for better reporting.
+
+# Testing Strategy
+
+- **Unit:** `ChromosomeFields.validate()`/`.normalised()` (combination matrix incl. mandatory
+  location and `Nuclear`); `MetadataResolver` precedence (master-only, header-only, both,
+  gap-fill, neither).
+- **Integration:** `GFF3HeaderIntegrationTest`-style cases exercising `--master-entry` alone,
+  `--fasta-header` alone, and both together for the same accession, asserting the resolved
+  precedence and the emitted EMBL `/organelle` (or its absence for `Nuclear`).
+- **Regression:** existing `GFF3MapperTest`, `FastaHeaderFormatValidationTest`,
+  `ControlledVocabularyUtilsTest`, `FastaHeaderNormalisationFixTest` updated to the mandatory +
+  `Nuclear` model.
+
+# Deployment & Operations
+
+No deployment or operational change; internal refactor of the conversion pipeline. Behaviour
+change is limited to metadata validation/precedence during GFF3-to-EMBL conversion.
+
+# Related Documentation & Resources
+
+- `docs/spec-fasta-header-to-embl-entry-mapping.md`
+- `docs/0003_validation_engine.md`, `docs/0006_validation_priority.md`,
+  `docs/0005_validation_context.md`
+- ENA assembly submission docs (Chromosome List File):
+  <https://ena-docs.readthedocs.io/en/latest/submit/fileprep/assembly.html>
+- Code: `gff3toff/GFF3Mapper.java`, `metadata/`, `sequence/fasta/header/`,
+  `validation/builtin/FastaHeaderFormatValidation.java`, `validation/fix/FastaHeaderNormalisationFix.java`
+- PR: <https://github.com/enasequence/gff3tools/pull/141>

--- a/docs/2607071200_effective_metadata_resolution.md
+++ b/docs/2607071200_effective_metadata_resolution.md
@@ -46,12 +46,12 @@ of this tool owning validation rather than deferring to downstream EMBL validati
 
 After discussion with the team, **`chromosome_location` is a mandatory attribute** when a
 chromosome is described (i.e. whenever `chromosome_name` and `chromosome_type` are present),
-rather than optional-with-an-implied-nuclear-default. To keep the nuclear/cytoplasmic default
-expressible, **`Nuclear` is supported as an allowed value** of the controlled vocabulary. This
-supersedes the interim change on branch `TTENA-258-fastaheader-fixes-and-moved-validations`
-(commit `cdd6822`) that had made `chromosome_location` optional and stripped a submitted
-`"nuclear"` to absent; that approach is reverted in favour of the mandatory + explicit-`Nuclear`
-model described here.
+rather than optional-with-an-implied-default. To keep the default location expressible,
+**`Nucleus` (eukaryotic) and `Cytoplasm` (prokaryotic/plasmid) are supported as allowed values**
+of the controlled vocabulary, both mapping to no `/organelle` qualifier. This supersedes the
+interim change on branch `TTENA-258-fastaheader-fixes-and-moved-validations` (commit `cdd6822`)
+that had made `chromosome_location` optional and stripped a submitted `"nuclear"` to absent; that
+approach is reverted in favour of the mandatory + explicit-default-value model described here.
 
 # Usage Guidelines
 
@@ -63,12 +63,13 @@ model described here.
 - **Chromosome fields (per team decision):**
   - Allowed combinations: *none* (unplaced contig), *chromosome_name only* (unlocalised), or
     *chromosome_name + chromosome_type + chromosome_location* (chromosome).
-  - `chromosome_location` is mandatory for the chromosome combination; use `Nuclear` for a
-    chromosome residing in the nucleus (or cytoplasm for prokaryotes). Organelle chromosomes use
-    the INSDC `/organelle` values (`Mitochondrion`, `Chloroplast`, …).
+  - `chromosome_location` is mandatory for the chromosome combination; use `Nucleus` for a
+    eukaryotic chromosome residing in the nucleus or `Cytoplasm` for a prokaryotic
+    chromosome/plasmid. Organelle chromosomes use the INSDC `/organelle` values (`Mitochondrion`,
+    `Chloroplast`, …).
 - **Extending vocabularies:** add values to `ControlledVocabularyUtils.ChromosomeLocation`
-  (canonical casing as the enum value). `Nuclear` is a gff3tools extension of the INSDC
-  `/organelle` list; it maps to *no* `/organelle` qualifier in EMBL output.
+  (canonical casing as the enum value). `Nucleus` and `Cytoplasm` are gff3tools extensions of the
+  INSDC `/organelle` list; both map to *no* `/organelle` qualifier in EMBL output.
 
 # System Overview / High-Level Design
 
@@ -127,8 +128,8 @@ public record ChromosomeFields(String name, String type, String location) {
 ```
 
 `ControlledVocabularyUtils.ChromosomeLocation` keeps the 18 INSDC `/organelle` values **plus**
-`NUCLEAR("Nuclear")`, documented as a gff3tools extension that maps to no `/organelle`
-qualifier.
+`NUCLEUS("Nucleus")` and `CYTOPLASM("Cytoplasm")`, gff3tools extensions that both map to no
+`/organelle` qualifier (the eukaryotic and prokaryotic/plasmid defaults respectively).
 
 ## `MetadataResolver`
 
@@ -169,7 +170,7 @@ private void applyMetadata(GFF3SequenceRegion region, Entry entry, Sequence seq,
 }
 ```
 
-`mapChromosomeLocation` keeps mapping `Nuclear` (case-insensitively) to no `/organelle`
+`mapChromosomeLocation` keeps mapping `Nucleus`/`Cytoplasm` (case-insensitively) to no `/organelle`
 qualifier; all other values resolve via the controlled vocabulary, and an unrecognised value is
 rejected rather than passed through.
 
@@ -189,10 +190,10 @@ rejected rather than passed through.
   closes the "no validation on master" gap, but does not address the silent cross-source
   fall-through, because neither source is individually wrong. Rejected as insufficient given both
   sources routinely coexist.
-- **`chromosome_location` optional with implied nuclear default** (interim commit `cdd6822`).
-  Faithful to the ENA "optional fourth column" wording, but leaves the nuclear case implicit and
+- **`chromosome_location` optional with implied default** (interim commit `cdd6822`).
+  Faithful to the ENA "optional fourth column" wording, but leaves the default case implicit and
   under-specified. Superseded by the team decision to make the attribute mandatory with explicit
-  `Nuclear`.
+  `Nucleus`/`Cytoplasm` values.
 - **Full unification of the two providers into one metadata model.** Larger refactor of the
   provider chain; deferred — the resolver captures the merge without forcing the providers to
   merge upstream.
@@ -211,14 +212,14 @@ rejected rather than passed through.
 # Testing Strategy
 
 - **Unit:** `ChromosomeFields.validate()`/`.normalised()` (combination matrix incl. mandatory
-  location and `Nuclear`); `MetadataResolver` precedence (master-only, header-only, both,
+  location and `Nucleus`/`Cytoplasm`); `MetadataResolver` precedence (master-only, header-only, both,
   gap-fill, neither).
 - **Integration:** `GFF3HeaderIntegrationTest`-style cases exercising `--master-entry` alone,
   `--fasta-header` alone, and both together for the same accession, asserting the resolved
-  precedence and the emitted EMBL `/organelle` (or its absence for `Nuclear`).
+  precedence and the emitted EMBL `/organelle` (or its absence for `Nucleus`/`Cytoplasm`).
 - **Regression:** existing `GFF3MapperTest`, `FastaHeaderFormatValidationTest`,
   `ControlledVocabularyUtilsTest`, `FastaHeaderNormalisationFixTest` updated to the mandatory +
-  `Nuclear` model.
+  `Nucleus`/`Cytoplasm` model.
 
 # Deployment & Operations
 

--- a/docs/spec-fasta-header-to-embl-entry-mapping.md
+++ b/docs/spec-fasta-header-to-embl-entry-mapping.md
@@ -41,7 +41,7 @@ without needing a FASTA file or to supplement headers not embedded in the FASTA 
    | Linkage Group      | `/linkage_group`|
    | Monopartite        | _(no qualifier)_|
 
-   `chromosome_location` maps to `/organelle` (lowercased). `"Nuclear"` produces no qualifier.
+   `chromosome_location` maps to `/organelle` (lowercased). `"Nucleus"` and `"Cytoplasm"` produce no qualifier.
    All other values are passed through; downstream EMBL validation checks qualifier values.
 
 6. **FR-6 — Per-entry lookup**
@@ -84,7 +84,7 @@ without needing a FASTA file or to supplement headers not embedded in the FASTA 
 | `topology`             | Yes       | `sequence.setTopology(Sequence.Topology.LINEAR/CIRCULAR)`         | ID line field 3             |
 | `chromosome_name`      | No        | `sourceFt.addQualifier("chromosome", value)`                      | FT source /chromosome       |
 | `chromosome_type`      | No        | mapped to `/plasmid`, `/segment`, `/chromosome`, or `/linkage_group` | FT source qualifier      |
-| `chromosome_location`  | No        | `sourceFt.addQualifier("organelle", lowercased_value)` (when non-nuclear) | FT source /organelle |
+| `chromosome_location`  | No        | `sourceFt.addQualifier("organelle", lowercased_value)` (except `Nucleus`/`Cytoplasm`, which produce no qualifier) | FT source /organelle |
 
 ### Header Source Architecture
 

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/cli/AbstractCommand.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/cli/AbstractCommand.java
@@ -73,8 +73,19 @@ public abstract class AbstractCommand implements Runnable {
         ValidationEngineBuilder builder =
                 new ValidationEngineBuilder().overrideMethodRules(ruleOverrides).failFast(failFast);
 
+        boolean suppliedFastaHeaderProvider = false;
         for (ContextProvider<?> provider : additionalProviders) {
             builder.withProvider(provider);
+            if (provider.type() == FastaHeaderProvider.class) {
+                suppliedFastaHeaderProvider = true;
+            }
+        }
+
+        // When no caller supplies a FASTA header source, keep the autodetected (empty)
+        // FastaHeaderProvider out of the context. Otherwise header-aware rules such as
+        // FASTA_HEADER_MAPPING would fire against accessions for which no header was ever provided.
+        if (!suppliedFastaHeaderProvider) {
+            builder.excludeProvider(FastaHeaderProvider.class);
         }
 
         return builder.build();

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/cli/AbstractCommand.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/cli/AbstractCommand.java
@@ -73,19 +73,12 @@ public abstract class AbstractCommand implements Runnable {
         ValidationEngineBuilder builder =
                 new ValidationEngineBuilder().overrideMethodRules(ruleOverrides).failFast(failFast);
 
-        boolean suppliedFastaHeaderProvider = false;
+        // Providers gate their own registration via ContextProvider#isActive(). An empty
+        // FastaHeaderProvider (no header source supplied) reports inactive and is kept off the
+        // context, so header-aware rules such as FASTA_HEADER_MAPPING stay inert unless a caller
+        // supplies a real header source.
         for (ContextProvider<?> provider : additionalProviders) {
             builder.withProvider(provider);
-            if (provider.type() == FastaHeaderProvider.class) {
-                suppliedFastaHeaderProvider = true;
-            }
-        }
-
-        // When no caller supplies a FASTA header source, keep the autodetected (empty)
-        // FastaHeaderProvider out of the context. Otherwise header-aware rules such as
-        // FASTA_HEADER_MAPPING would fire against accessions for which no header was ever provided.
-        if (!suppliedFastaHeaderProvider) {
-            builder.excludeProvider(FastaHeaderProvider.class);
         }
 
         return builder.build();

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/cli/FileConversionCommand.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/cli/FileConversionCommand.java
@@ -159,7 +159,7 @@ public class FileConversionCommand extends AbstractCommand {
                             writingToFile ? Files.newBufferedWriter(effectiveOutputPath) : createStdoutWriter()) {
                 SequenceLookup sequenceLookup = compositeProvider.hasSources() ? compositeProvider.get(null) : null;
                 // Only register the FASTA header provider when it actually carries a header source.
-                // An empty provider would otherwise trip header-aware rules (e.g. FASTA_HEADER_MAPPING)
+                // An empty provider will otherwise trip header-aware rules (e.g. FASTA_HEADER_MAPPING)
                 // for conversions run without any FASTA header input.
                 ContextProvider<?>[] providers = headerProvider.hasSources()
                         ? new ContextProvider<?>[] {compositeProvider, metadataProvider, headerProvider}

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/cli/FileConversionCommand.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/cli/FileConversionCommand.java
@@ -39,6 +39,7 @@ import uk.ac.ebi.embl.gff3tools.sequence.SequenceLookup;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
 import uk.ac.ebi.embl.gff3tools.tsvconverter.TSVToGFF3Converter;
 import uk.ac.ebi.embl.gff3tools.utils.GzipUtils;
+import uk.ac.ebi.embl.gff3tools.validation.ContextProvider;
 import uk.ac.ebi.embl.gff3tools.validation.ValidationEngine;
 import uk.ac.ebi.embl.gff3tools.validation.meta.RuleSeverity;
 import uk.ac.ebi.embl.gff3tools.validation.provider.CompositeSequenceProvider;
@@ -157,8 +158,13 @@ public class FileConversionCommand extends AbstractCommand {
                     BufferedWriter outputWriter =
                             writingToFile ? Files.newBufferedWriter(effectiveOutputPath) : createStdoutWriter()) {
                 SequenceLookup sequenceLookup = compositeProvider.hasSources() ? compositeProvider.get(null) : null;
-                try (ValidationEngine engine =
-                        initValidationEngine(ruleOverrides, compositeProvider, metadataProvider, headerProvider)) {
+                // Only register the FASTA header provider when it actually carries a header source.
+                // An empty provider would otherwise trip header-aware rules (e.g. FASTA_HEADER_MAPPING)
+                // for conversions run without any FASTA header input.
+                ContextProvider<?>[] providers = headerProvider.hasSources()
+                        ? new ContextProvider<?>[] {compositeProvider, metadataProvider, headerProvider}
+                        : new ContextProvider<?>[] {compositeProvider, metadataProvider};
+                try (ValidationEngine engine = initValidationEngine(ruleOverrides, providers)) {
                     Converter converter =
                             getConverter(engine, fromFileType, toFileType, inputFastaSourceFinal, sequenceLookup);
                     converter.convert(inputReader, outputWriter);

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/cli/FileConversionCommand.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/cli/FileConversionCommand.java
@@ -38,6 +38,7 @@ import uk.ac.ebi.embl.gff3tools.metadata.MasterMetadataProvider;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
 import uk.ac.ebi.embl.gff3tools.tsvconverter.TSVToGFF3Converter;
 import uk.ac.ebi.embl.gff3tools.utils.GzipUtils;
+import uk.ac.ebi.embl.gff3tools.validation.ContextProvider;
 import uk.ac.ebi.embl.gff3tools.validation.ValidationEngine;
 import uk.ac.ebi.embl.gff3tools.validation.meta.RuleSeverity;
 import uk.ac.ebi.embl.gff3tools.validation.provider.CompositeSequenceProvider;
@@ -155,8 +156,13 @@ public class FileConversionCommand extends AbstractCommand {
                             : createInputReader();
                     BufferedWriter outputWriter =
                             writingToFile ? Files.newBufferedWriter(effectiveOutputPath) : createStdoutWriter()) {
-                try (ValidationEngine engine =
-                        initValidationEngine(ruleOverrides, compositeProvider, metadataProvider, headerProvider)) {
+                // Only register the FASTA header provider when it actually carries a header source.
+                // An empty provider would otherwise trip header-aware rules (e.g. FASTA_HEADER_MAPPING)
+                // for conversions run without any FASTA header input.
+                ContextProvider<?>[] providers = headerProvider.hasSources()
+                        ? new ContextProvider<?>[] {compositeProvider, metadataProvider, headerProvider}
+                        : new ContextProvider<?>[] {compositeProvider, metadataProvider};
+                try (ValidationEngine engine = initValidationEngine(ruleOverrides, providers)) {
                     Converter converter = getConverter(engine, fromFileType, toFileType, inputFastaSourceFinal);
                     converter.convert(inputReader, outputWriter);
                 }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/cli/FileConversionCommand.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/cli/FileConversionCommand.java
@@ -158,12 +158,10 @@ public class FileConversionCommand extends AbstractCommand {
                     BufferedWriter outputWriter =
                             writingToFile ? Files.newBufferedWriter(effectiveOutputPath) : createStdoutWriter()) {
                 SequenceLookup sequenceLookup = compositeProvider.hasSources() ? compositeProvider.get(null) : null;
-                // Only register the FASTA header provider when it actually carries a header source.
-                // An empty provider will otherwise trip header-aware rules (e.g. FASTA_HEADER_MAPPING)
-                // for conversions run without any FASTA header input.
-                ContextProvider<?>[] providers = headerProvider.hasSources()
-                        ? new ContextProvider<?>[] {compositeProvider, metadataProvider, headerProvider}
-                        : new ContextProvider<?>[] {compositeProvider, metadataProvider};
+                // The header provider self-skips when it carries no header source (see
+                // FastaHeaderProvider#isActive), so an empty one never lands on the context and
+                // header-aware rules (e.g. FASTA_HEADER_MAPPING) stay inert.
+                ContextProvider<?>[] providers = {compositeProvider, metadataProvider, headerProvider};
                 try (ValidationEngine engine = initValidationEngine(ruleOverrides, providers)) {
                     Converter converter =
                             getConverter(engine, fromFileType, toFileType, inputFastaSourceFinal, sequenceLookup);

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/gff3toff/GFF3Mapper.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/gff3toff/GFF3Mapper.java
@@ -1061,15 +1061,12 @@ public class GFF3Mapper {
     }
 
     /**
-     * Maps chromosome_location to the EMBL /organelle qualifier on the source feature. Per the ENA
-     * assembly submission docs, a chromosome is assumed nuclear (no /organelle qualifier) when this
-     * field is absent; "nuclear" is handled as a case-insensitive synonym for absent here as a
-     * defensive fallback for inputs (e.g. the legacy MasterMetadata/master-JSON path) that were not
-     * normalised by {@code FastaHeaderNormalisationFix}, which strips it to null for the FastaHeader
-     * path. All other values are matched case-insensitively against the INSDC {@code /organelle}
-     * controlled vocabulary ({@link ControlledVocabularyUtils.ChromosomeLocation}); this tool now
-     * owns validation of that vocabulary, so unrecognised values are rejected here rather than
-     * passed through to EMBL.
+     * Maps chromosome_location to the EMBL /organelle qualifier on the source feature. "Nuclear" is
+     * an allowed value denoting the nuclear/cytoplasmic default and maps to no /organelle qualifier
+     * (handled case-insensitively). All other values are matched case-insensitively against the
+     * INSDC {@code /organelle} controlled vocabulary ({@link ControlledVocabularyUtils.ChromosomeLocation});
+     * this tool now owns validation of that vocabulary, so unrecognised values are rejected here
+     * rather than passed through to EMBL.
      *
      * @param chromosomeLocation  the chromosome location string from the FASTA header
      * @param sourceFt            the source feature to add the qualifier to

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/gff3toff/GFF3Mapper.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/gff3toff/GFF3Mapper.java
@@ -53,6 +53,7 @@ import uk.ac.ebi.embl.gff3tools.metadata.SubmissionAccount;
 import uk.ac.ebi.embl.gff3tools.metadata.SubmitterDetails;
 import uk.ac.ebi.embl.gff3tools.sequence.SequenceLookup;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.ControlledVocabularyUtils;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
 import uk.ac.ebi.embl.gff3tools.utils.ConversionEntry;
 import uk.ac.ebi.embl.gff3tools.utils.ConversionUtils;
@@ -1060,21 +1061,34 @@ public class GFF3Mapper {
     }
 
     /**
-     * Maps chromosome_location to the EMBL /organelle qualifier on the source feature.
-     * "Nuclear" is the default and produces no qualifier. All other values are passed through
-     * as-is (lowercased); downstream EMBL validation checks qualifier values.
+     * Maps chromosome_location to the EMBL /organelle qualifier on the source feature. Per the ENA
+     * assembly submission docs, a chromosome is assumed nuclear (no /organelle qualifier) when this
+     * field is absent; "nuclear" is handled as a case-insensitive synonym for absent here as a
+     * defensive fallback for inputs (e.g. the legacy MasterMetadata/master-JSON path) that were not
+     * normalised by {@code FastaHeaderNormalisationFix}, which strips it to null for the FastaHeader
+     * path. All other values are matched case-insensitively against the INSDC {@code /organelle}
+     * controlled vocabulary ({@link ControlledVocabularyUtils.ChromosomeLocation}); this tool now
+     * owns validation of that vocabulary, so unrecognised values are rejected here rather than
+     * passed through to EMBL.
      *
      * @param chromosomeLocation  the chromosome location string from the FASTA header
      * @param sourceFt            the source feature to add the qualifier to
      */
     private void mapChromosomeLocation(String chromosomeLocation, SourceFeature sourceFt) {
-        String normalised = chromosomeLocation.toLowerCase();
-
-        if ("nuclear".equals(normalised)) {
+        if ("nuclear".equalsIgnoreCase(chromosomeLocation)) {
             // Nuclear is the default -- no organelle qualifier needed
             return;
         }
 
-        sourceFt.addQualifier("organelle", normalised);
+        Optional<String> canonical = ControlledVocabularyUtils.canonicalise(
+                ControlledVocabularyUtils.ChromosomeLocation.class, chromosomeLocation);
+        if (canonical.isEmpty()) {
+            LOGGER.warn(
+                    "Unrecognised chromosome_location value '{}'; skipping organelle qualifier mapping",
+                    chromosomeLocation);
+            return;
+        }
+
+        sourceFt.addQualifier("organelle", canonical.get().toLowerCase());
     }
 }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/gff3toff/GFF3Mapper.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/gff3toff/GFF3Mapper.java
@@ -1072,7 +1072,10 @@ public class GFF3Mapper {
      * @param sourceFt            the source feature to add the qualifier to
      */
     private void mapChromosomeLocation(String chromosomeLocation, SourceFeature sourceFt) {
-        if ("nucleus".equalsIgnoreCase(chromosomeLocation) || "cytoplasm".equalsIgnoreCase(chromosomeLocation)) {
+        if (ControlledVocabularyUtils.ChromosomeLocation.NUCLEUS.getValue().equalsIgnoreCase(chromosomeLocation)
+                || ControlledVocabularyUtils.ChromosomeLocation.CYTOPLASM
+                        .getValue()
+                        .equalsIgnoreCase(chromosomeLocation)) {
             // Nucleus/Cytoplasm denote the default location -- no organelle qualifier needed
             return;
         }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/gff3toff/GFF3Mapper.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/gff3toff/GFF3Mapper.java
@@ -1061,19 +1061,19 @@ public class GFF3Mapper {
     }
 
     /**
-     * Maps chromosome_location to the EMBL /organelle qualifier on the source feature. "Nuclear" is
-     * an allowed value denoting the nuclear/cytoplasmic default and maps to no /organelle qualifier
-     * (handled case-insensitively). All other values are matched case-insensitively against the
-     * INSDC {@code /organelle} controlled vocabulary ({@link ControlledVocabularyUtils.ChromosomeLocation});
-     * this tool now owns validation of that vocabulary, so unrecognised values are rejected here
-     * rather than passed through to EMBL.
+     * Maps chromosome_location to the EMBL /organelle qualifier on the source feature. "Nucleus"
+     * (eukaryotic default) and "Cytoplasm" (prokaryotic/plasmid default) are allowed values that map
+     * to no /organelle qualifier (handled case-insensitively). All other values are matched
+     * case-insensitively against the INSDC {@code /organelle} controlled vocabulary
+     * ({@link ControlledVocabularyUtils.ChromosomeLocation}); this tool now owns validation of that
+     * vocabulary, so unrecognised values are rejected here rather than passed through to EMBL.
      *
      * @param chromosomeLocation  the chromosome location string from the FASTA header
      * @param sourceFt            the source feature to add the qualifier to
      */
     private void mapChromosomeLocation(String chromosomeLocation, SourceFeature sourceFt) {
-        if ("nuclear".equalsIgnoreCase(chromosomeLocation)) {
-            // Nuclear is the default -- no organelle qualifier needed
+        if ("nucleus".equalsIgnoreCase(chromosomeLocation) || "cytoplasm".equalsIgnoreCase(chromosomeLocation)) {
+            // Nucleus/Cytoplasm denote the default location -- no organelle qualifier needed
             return;
         }
 

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/FastaHeaderProvider.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/FastaHeaderProvider.java
@@ -46,6 +46,16 @@ public class FastaHeaderProvider implements ContextProvider<FastaHeaderProvider>
     }
 
     /**
+     * A header provider with no sources can never resolve a header, so it is kept off the
+     * context entirely. This stops header-aware rules (e.g. FASTA_HEADER_MAPPING) from firing
+     * against accessions for which no header was ever supplied.
+     */
+    @Override
+    public boolean isActive() {
+        return hasSources();
+    }
+
+    /**
      * Registers a header source. Sources are queried in registration order.
      */
     public void addSource(FastaHeaderSource source) {

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/FastaHeaderProvider.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/FastaHeaderProvider.java
@@ -53,6 +53,14 @@ public class FastaHeaderProvider implements ContextProvider<FastaHeaderProvider>
     }
 
     /**
+     * Returns {@code true} if at least one header source is registered. A provider with no sources
+     * can never resolve a header, so callers may choose not to register it at all.
+     */
+    public boolean hasSources() {
+        return !sources.isEmpty();
+    }
+
+    /**
      * Returns the first non-empty header for the given seqId across all registered sources.
      */
     public Optional<FastaHeader> getHeader(String seqId) {

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
@@ -119,6 +119,7 @@ public final class ControlledVocabularyUtils {
             this.value = value;
         }
 
+        @Override
         public String getValue() {
             return value;
         }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
@@ -59,6 +59,7 @@ public final class ControlledVocabularyUtils {
             this.value = value;
         }
 
+        @Override
         public String getValue() {
             return value;
         }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+
+public final class ControlledVocabularyUtils {
+    private ControlledVocabularyUtils() {}
+
+    public interface ControlledVocabulary {
+        String getValue();
+    }
+
+    public enum MolType implements ControlledVocabulary {
+        GENOMIC_DNA("genomic DNA"),
+        GENOMIC_RNA("genomic RNA"),
+        MRNA("mRNA"),
+        TRNA("tRNA"),
+        RRNA("rRNA"),
+        OTHER_RNA("other RNA"),
+        OTHER_DNA("other DNA"),
+        TRANSCRIBED_RNA("transcribed RNA"),
+        VIRAL_CRNA("viral cRNA"),
+        UNASSIGNED_DNA("unassigned DNA"),
+        UNASSIGNED_RNA("unassigned RNA");
+
+        private final String value;
+
+        MolType(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public static Optional<MolType> fromValue(String value) {
+            return fromControlledVocabularyValue(MolType.class, value);
+        }
+    }
+
+    public enum Topology implements ControlledVocabulary {
+        LINEAR("linear"),
+        CIRCULAR("circular");
+
+        private final String value;
+
+        Topology(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public static Optional<Topology> fromValue(String value) {
+            return fromControlledVocabularyValue(Topology.class, value);
+        }
+    }
+
+    public enum ChromosomeType implements ControlledVocabulary {
+        CHROMOSOME("chromosome"),
+        PLASMID("plasmid"),
+        LINKAGE_GROUP("linkage_group"),
+        MONOPARTITE("monopartite"),
+        SEGMENTED("segmented"),
+        MULTIPARTITE("multipartite");
+
+        private final String value;
+
+        ChromosomeType(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public static Optional<ChromosomeType> fromValue(String value) {
+            return fromControlledVocabularyValue(ChromosomeType.class, value);
+        }
+    }
+
+    public enum ChromosomeLocation implements ControlledVocabulary {
+        MACRONUCLEAR("Macronuclear"),
+        NUCLEOMORPH("Nucleomorph"),
+        MITOCHONDRION("Mitochondrion"),
+        KINETOPLAST("Kinetoplast"),
+        CHLOROPLAST("Chloroplast"),
+        CHROMOPLAST("Chromoplast"),
+        PLASTID("Plastid"),
+        VIRION("Virion"),
+        PHAGE("Phage"),
+        PROVIRAL("Proviral"),
+        PROPHAGE("Prophage"),
+        VIROID("Viroid"),
+        CYANELLE("Cyanelle"),
+        APICOPLAST("Apicoplast"),
+        LEUCOPLAST("Leucoplast"),
+        PROPLASTID("Proplastid"),
+        HYDROGENOSOME("Hydrogenosome"),
+        CHROMATOPHORE("Chromatophore");
+
+        private final String value;
+
+        ChromosomeLocation(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public static Optional<ChromosomeLocation> fromValue(String value) {
+            return fromControlledVocabularyValue(ChromosomeLocation.class, value);
+        }
+    }
+
+    public static Optional<MolType> normaliseMolType(FastaHeader header) {
+        return normalise(header, FastaHeader::getMoleculeType, MolType.class);
+    }
+
+    public static Optional<Topology> normaliseTopology(FastaHeader header) {
+        return normalise(header, FastaHeader::getTopology, Topology.class);
+    }
+
+    public static Optional<ChromosomeType> normaliseChromosomeType(FastaHeader header) {
+        return normalise(header, FastaHeader::getChromosomeType, ChromosomeType.class);
+    }
+
+    public static Optional<ChromosomeLocation> normaliseChromosomeLocation(FastaHeader header) {
+        return normalise(header, FastaHeader::getChromosomeLocation, ChromosomeLocation.class);
+    }
+
+    private static <T extends Enum<T> & ControlledVocabulary> Optional<T> normalise(
+            FastaHeader header, Function<FastaHeader, String> valueExtractor, Class<T> vocabularyType) {
+        if (header == null) {
+            return Optional.empty();
+        }
+
+        return fromControlledVocabularyValue(vocabularyType, valueExtractor.apply(header));
+    }
+
+    private static <T extends Enum<T> & ControlledVocabulary> Optional<T> fromControlledVocabularyValue(
+            Class<T> vocabularyType, String value) {
+        return Arrays.stream(vocabularyType.getEnumConstants())
+                .filter(vocabulary -> vocabulary.getValue().equals(value))
+                .findFirst();
+    }
+}

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
@@ -40,6 +40,7 @@ public final class ControlledVocabularyUtils {
             this.value = value;
         }
 
+        @Override
         public String getValue() {
             return value;
         }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
@@ -83,6 +83,7 @@ public final class ControlledVocabularyUtils {
             this.value = value;
         }
 
+        @Override
         public String getValue() {
             return value;
         }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
@@ -94,6 +94,15 @@ public final class ControlledVocabularyUtils {
         }
     }
 
+    /**
+     * chromosome_location values, i.e. the INSDC-controlled {@code /organelle} vocabulary as listed
+     * in the <a href="https://ena-docs.readthedocs.io/en/latest/submit/fileprep/assembly.html">ENA
+     * assembly submission docs</a> (Chromosome List File, optional fourth column). This field is
+     * optional and independent of chromosome_name/chromosome_type: eukaryotic chromosomes are
+     * assumed nuclear (and prokaryotic chromosomes/plasmids cytoplasmic) whenever it is absent, so
+     * there is deliberately no "nuclear" entry here -- see {@code FastaHeaderNormalisationFix}, which
+     * normalises a submitted literal "nuclear" value back to absent.
+     */
     public enum ChromosomeLocation implements ControlledVocabulary {
         MACRONUCLEAR("Macronuclear"),
         NUCLEOMORPH("Nucleomorph"),

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
@@ -157,4 +157,29 @@ public final class ControlledVocabularyUtils {
                 .filter(vocabulary -> vocabulary.getValue().equals(value))
                 .findFirst();
     }
+
+    /**
+     * Resolves a raw value to its canonical controlled-vocabulary form.
+     *
+     * <p>The value is first trimmed of leading/trailing whitespace and has dashes replaced with
+     * underscores, then matched case-insensitively against the vocabulary's allowed values. When a
+     * match is found the canonical value (with its original casing and spacing) is returned;
+     * otherwise the result is empty and callers should leave the value untouched.
+     *
+     * @param vocabularyType the controlled vocabulary to match against
+     * @param value the raw value to canonicalise
+     * @return the canonical value, or empty if the input does not match any allowed value
+     */
+    public static <T extends Enum<T> & ControlledVocabulary> Optional<String> canonicalise(
+            Class<T> vocabularyType, String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+
+        String candidate = value.strip().replace('-', '_');
+        return Arrays.stream(vocabularyType.getEnumConstants())
+                .map(ControlledVocabulary::getValue)
+                .filter(canonical -> canonical.equalsIgnoreCase(candidate))
+                .findFirst();
+    }
 }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
@@ -95,15 +95,16 @@ public final class ControlledVocabularyUtils {
     }
 
     /**
-     * chromosome_location values, i.e. the INSDC-controlled {@code /organelle} vocabulary as listed
-     * in the <a href="https://ena-docs.readthedocs.io/en/latest/submit/fileprep/assembly.html">ENA
-     * assembly submission docs</a> (Chromosome List File, optional fourth column). This field is
-     * optional and independent of chromosome_name/chromosome_type: eukaryotic chromosomes are
-     * assumed nuclear (and prokaryotic chromosomes/plasmids cytoplasmic) whenever it is absent, so
-     * there is deliberately no "nuclear" entry here -- see {@code FastaHeaderNormalisationFix}, which
-     * normalises a submitted literal "nuclear" value back to absent.
+     * chromosome_location values: the INSDC-controlled {@code /organelle} vocabulary listed in the
+     * <a href="https://ena-docs.readthedocs.io/en/latest/submit/fileprep/assembly.html">ENA assembly
+     * submission docs</a> (Chromosome List File, fourth column), extended with {@link #NUCLEAR}. Per
+     * the team decision (2026-07), chromosome_location is a mandatory attribute when a chromosome is
+     * described, so the nuclear/cytoplasmic default is expressed explicitly with {@code Nuclear}
+     * rather than by omitting the field. {@code Nuclear} is a gff3tools extension of the INSDC list
+     * and maps to no {@code /organelle} qualifier in EMBL output.
      */
     public enum ChromosomeLocation implements ControlledVocabulary {
+        NUCLEAR("Nuclear"),
         MACRONUCLEAR("Macronuclear"),
         NUCLEOMORPH("Nucleomorph"),
         MITOCHONDRION("Mitochondrion"),

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtils.java
@@ -97,14 +97,16 @@ public final class ControlledVocabularyUtils {
     /**
      * chromosome_location values: the INSDC-controlled {@code /organelle} vocabulary listed in the
      * <a href="https://ena-docs.readthedocs.io/en/latest/submit/fileprep/assembly.html">ENA assembly
-     * submission docs</a> (Chromosome List File, fourth column), extended with {@link #NUCLEAR}. Per
-     * the team decision (2026-07), chromosome_location is a mandatory attribute when a chromosome is
-     * described, so the nuclear/cytoplasmic default is expressed explicitly with {@code Nuclear}
-     * rather than by omitting the field. {@code Nuclear} is a gff3tools extension of the INSDC list
-     * and maps to no {@code /organelle} qualifier in EMBL output.
+     * submission docs</a> (Chromosome List File, fourth column), extended with {@link #NUCLEUS} and
+     * {@link #CYTOPLASM}. Per the team decision (2026-07), chromosome_location is a mandatory
+     * attribute when a chromosome is described, so the default location is expressed explicitly with
+     * {@code Nucleus} (the eukaryotic default) or {@code Cytoplasm} (the prokaryotic/plasmid default)
+     * rather than by omitting the field. Both are gff3tools extensions of the INSDC list and map to
+     * no {@code /organelle} qualifier in EMBL output.
      */
     public enum ChromosomeLocation implements ControlledVocabulary {
-        NUCLEAR("Nuclear"),
+        NUCLEUS("Nucleus"),
+        CYTOPLASM("Cytoplasm"),
         MACRONUCLEAR("Macronuclear"),
         NUCLEOMORPH("Nucleomorph"),
         MITOCHONDRION("Mitochondrion"),

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/ContextProvider.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/ContextProvider.java
@@ -27,6 +27,19 @@ public interface ContextProvider<T> {
     Class<T> type();
 
     /**
+     * Returns true if this provider has enough state to be useful on the context.
+     * A provider returning false is silently skipped — neither autodetected nor
+     * explicitly registered instances of this type land on the context.
+     *
+     * <p>Override when a provider may be constructed but conditionally empty
+     * (e.g. no sources configured). Evaluated once at registration time, so the
+     * provider's state must be settled before the engine is built. Defaults to true.
+     */
+    default boolean isActive() {
+        return true;
+    }
+
+    /**
      * Lifecycle hook called after all providers are registered in the context
      * but before any fixes or validators are initialized.
      */

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/ValidationEngineBuilder.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/ValidationEngineBuilder.java
@@ -22,6 +22,7 @@ public class ValidationEngineBuilder {
     private final ValidationConfig validationConfig;
     private boolean failFast = false;
     private final List<ContextProvider<?>> providerOverrides = new ArrayList<>();
+    private final Set<Class<?>> excludedProviderTypes = new HashSet<>();
     private boolean providerClasspathScanningEnabled = true;
     private boolean validationClassPathScanningEnabled = true;
     private final List<Fix> fixOverrides = new ArrayList<>();
@@ -37,6 +38,7 @@ public class ValidationEngineBuilder {
         ValidationRegistry registry = ValidationRegistry.builder()
                 .config(validationConfig)
                 .providers(providerOverrides)
+                .excludedProviderTypes(excludedProviderTypes)
                 .contextProviderClassPathScanningEnabled(providerClasspathScanningEnabled)
                 .validationClassPathScanningEnabled(validationClassPathScanningEnabled)
                 .fixes(fixOverrides)
@@ -66,6 +68,21 @@ public class ValidationEngineBuilder {
      */
     public ValidationEngineBuilder disableAutodetectContextProviders() {
         this.providerClasspathScanningEnabled = false;
+        return this;
+    }
+
+    /**
+     * Exclude a context provider type from the engine. The given type is never registered on the
+     * context, even if it would otherwise be autodetected via classpath scanning or supplied via
+     * {@link #withProvider(ContextProvider)}. This makes {@code context.contains(type)} return
+     * {@code false}, so rules that guard on the provider's presence become inert.
+     *
+     * @param providerType the provider value type to exclude (e.g. {@code FastaHeaderProvider.class})
+     * @return this builder for chaining
+     */
+    public ValidationEngineBuilder excludeProvider(Class<?> providerType) {
+        Objects.requireNonNull(providerType, "providerType must not be null");
+        excludedProviderTypes.add(providerType);
         return this;
     }
 

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/ValidationEngineBuilder.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/ValidationEngineBuilder.java
@@ -34,6 +34,13 @@ public class ValidationEngineBuilder {
         validationConfig = getValidationConfig();
     }
 
+    /**
+     * Assembles the configured registry and returns a ready-to-use {@link ValidationEngine}.
+     * Applies provider overrides/exclusions, classpath-scanning toggles, explicit fixes and
+     * validators, and the loaded severity configuration. Call once per engine.
+     *
+     * @return a new validation engine built from this builder's current state
+     */
     public ValidationEngine build() {
         ValidationRegistry registry = ValidationRegistry.builder()
                 .config(validationConfig)
@@ -74,10 +81,16 @@ public class ValidationEngineBuilder {
     /**
      * Exclude a context provider type from the engine. The given type is never registered on the
      * context, even if it would otherwise be autodetected via classpath scanning or supplied via
-     * {@link #withProvider(ContextProvider)}. This makes {@code context.contains(type)} return
-     * {@code false}, so rules that guard on the provider's presence become inert.
+     * {@link #withProvider(ContextProvider)}.
      *
-     * @param providerType the provider value type to exclude (e.g. {@code FastaHeaderProvider.class})
+     * <p>Exclusion always wins: the type is removed regardless of what a detected provider reports
+     * via {@link ContextProvider#isActive()}, so an active provider is dropped just the same as an
+     * inactive one.
+     *
+     * <p>As a result, {@code validationContext.contains(type)} returns {@code false}, so rules that guard on
+     * the provider's presence become inert.
+     *
+     * @param providerType the provider value type to exclude (e.g. {@code StringProvider.class})
      * @return this builder for chaining
      */
     public ValidationEngineBuilder excludeProvider(Class<?> providerType) {
@@ -123,26 +136,80 @@ public class ValidationEngineBuilder {
         return this;
     }
 
+    /**
+     * Sets the fail-fast policy for the built engine. When {@code true}, the engine stops at the
+     * first error instead of collecting all of them before reporting.
+     *
+     * @param failFast whether to abort on the first error
+     * @return this builder for chaining
+     */
     public ValidationEngineBuilder failFast(boolean failFast) {
         this.failFast = failFast;
         return this;
     }
 
+    /**
+     * Overrides the severity of individual validation rules. Keys are matched against the
+     * {@code @ValidationMethod.rule()} of each validation method, so the override targets a single
+     * method. Entries are merged over the defaults loaded from
+     * {@code default-rule-severities.properties}, so only the supplied rules change.
+     *
+     * <p>This filters at execution: the validation is still registered, but {@link ValidationEngine}
+     * consults the severity on every run, skipping the rule when it is {@code OFF} and otherwise
+     * governing how a violation is reported.
+     *
+     * @param map {@code @ValidationMethod.rule()} to severity overrides
+     * @return this builder for chaining
+     */
     public ValidationEngineBuilder overrideMethodRules(Map<String, RuleSeverity> map) {
         this.validationConfig.getRuleOverrides().putAll(map);
         return this;
     }
 
+    /**
+     * Toggles individual fixes on or off. Keys are matched against the {@code @FixMethod.rule()} of
+     * each fix method, so the override targets a single method. Entries are merged over the
+     * defaults, so only the supplied fixes change.
+     *
+     * <p>This filters at execution: the fix is still registered, but {@link ValidationEngine}
+     * skips it or includes it on every run.
+     *
+     * @param map {@code @FixMethod.rule()} to enabled flag overrides
+     * @return this builder for chaining
+     */
     public ValidationEngineBuilder overrideMethodFixs(Map<String, Boolean> map) {
         this.validationConfig.getFixOverrides().putAll(map);
         return this;
     }
 
+    /**
+     * Toggles whole validator/fix classes on or off. Keys are matched against the class-level
+     * {@code @Gff3Validation.name()} / {@code @Gff3Fix.name()}, so a single key disables every
+     * method that class declares. Entries are merged over the defaults, so only the supplied
+     * classes change.
+     *
+     * <p>Note this is a different namespace from {@link #overrideMethodRules(Map)} and
+     * {@link #overrideMethodFixs(Map)}, which key on per-method rules. For a single-method
+     * validator the class name and its method rule are the same string by convention, but for a
+     * multi-method class they differ.
+     *
+     * <p>This filters at registration: a disabled class is never built into a descriptor at all.
+     *
+     * @param map class-level {@code @Gff3Validation.name()} / {@code @Gff3Fix.name()} to enabled flag overrides
+     * @return this builder for chaining
+     */
     public ValidationEngineBuilder overrideClassRules(Map<String, Boolean> map) {
         this.validationConfig.getValidatorOverrides().putAll(map);
         return this;
     }
 
+    /**
+     * Loads the default {@link ValidationConfig} from {@code default-rule-severities.properties} on
+     * the classpath. Keys are routed by prefix: {@code rule.*} to severities, {@code fix.*} to fix
+     * toggles, and {@code class.*} to validator-class toggles.
+     *
+     * @return the default validation configuration
+     */
     private ValidationConfig getValidationConfig() {
         Map<String, RuleSeverity> severityOverrides = new HashMap<>();
         Map<String, Boolean> validatorOverrides = new HashMap<>();

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/ValidationRegistry.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/ValidationRegistry.java
@@ -97,17 +97,19 @@ public class ValidationRegistry {
 
         ValidationContext ctx = new ValidationContext();
 
-        // Explicitly registered providers, minus any whose type is excluded. Excluding a provider
-        // wins over both classpath autodetection and explicit registration, so the type ends up
-        // absent from the context entirely.
+        // Explicitly registered providers, minus any whose type is excluded or that report
+        // themselves inactive. Excluding a provider wins over both classpath autodetection and
+        // explicit registration; an inactive provider (e.g. one with no sources configured)
+        // self-skips. Either way the type ends up absent from the context entirely.
         List<ContextProvider<?>> explicitProviders = providers.stream()
                 .filter(provider -> !excludedProviderTypes.contains(provider.type()))
+                .filter(ContextProvider::isActive)
                 .collect(Collectors.toList());
 
         List<ContextProvider<?>> allProviders = new ArrayList<>();
         if (contextProviderClassPathScanningEnabled) {
             for (ContextProvider<?> provider : instantiateProviders()) {
-                if (excludedProviderTypes.contains(provider.type())) {
+                if (excludedProviderTypes.contains(provider.type()) || !provider.isActive()) {
                     continue;
                 }
                 allProviders.add(provider);

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/ValidationRegistry.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/ValidationRegistry.java
@@ -90,23 +90,32 @@ public class ValidationRegistry {
             @Singular List<ContextProvider<?>> providers,
             boolean contextProviderClassPathScanningEnabled,
             boolean validationClassPathScanningEnabled,
+            @Singular("excludedProviderType") Set<Class<?>> excludedProviderTypes,
             @Singular("fix") List<Fix> fixes,
             @Singular("validator") List<Validation> validators) {
         this.validationConfig = config;
 
         ValidationContext ctx = new ValidationContext();
 
-        List<ContextProvider<?>> allProviders;
+        // Explicitly registered providers, minus any whose type is excluded. Excluding a provider
+        // wins over both classpath autodetection and explicit registration, so the type ends up
+        // absent from the context entirely.
+        List<ContextProvider<?>> explicitProviders = providers.stream()
+                .filter(provider -> !excludedProviderTypes.contains(provider.type()))
+                .collect(Collectors.toList());
+
+        List<ContextProvider<?>> allProviders = new ArrayList<>();
         if (contextProviderClassPathScanningEnabled) {
-            allProviders = new ArrayList<>(instantiateProviders());
-            for (ContextProvider<?> provider : allProviders) {
+            for (ContextProvider<?> provider : instantiateProviders()) {
+                if (excludedProviderTypes.contains(provider.type())) {
+                    continue;
+                }
+                allProviders.add(provider);
                 ctx.register((Class<Object>) provider.type(), (ContextProvider<Object>) provider);
             }
-        } else {
-            allProviders = new ArrayList<>();
         }
 
-        for (ContextProvider<?> provider : providers) {
+        for (ContextProvider<?> provider : explicitProviders) {
             ctx.register((Class<Object>) provider.type(), (ContextProvider<Object>) provider);
         }
 
@@ -115,13 +124,13 @@ public class ValidationRegistry {
         // Ordering: classpath providers initialize first, then explicit providers. If a classpath
         // provider's initialize() depends on an explicit provider, it will NOT see it yet.
         Set<Class<?>> explicitTypes =
-                providers.stream().map(ContextProvider::type).collect(Collectors.toSet());
+                explicitProviders.stream().map(ContextProvider::type).collect(Collectors.toSet());
         for (ContextProvider<?> provider : allProviders) {
             if (!explicitTypes.contains(provider.type())) {
                 initializeProvider(provider, ctx);
             }
         }
-        for (ContextProvider<?> provider : providers) {
+        for (ContextProvider<?> provider : explicitProviders) {
             initializeProvider(provider, ctx);
         }
 

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/ChromosomeNameValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/ChromosomeNameValidation.java
@@ -134,7 +134,9 @@ public class ChromosomeNameValidation implements Validation {
     }
 
     private Optional<FastaHeader> fastaHeaderFor(String id) {
-        return context.get(FastaHeaderProvider.class).getHeader(id);
+        return context.contains(FastaHeaderProvider.class)
+                ? context.get(FastaHeaderProvider.class).getHeader(id)
+                : Optional.empty();
     }
 
     private static Optional<String> chromosomeName(FastaHeader header) {

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/ChromosomeNameValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/ChromosomeNameValidation.java
@@ -49,7 +49,7 @@ public class ChromosomeNameValidation implements Validation {
             rule = CHROMOSOME_NAME_UNIQUE_RULE,
             description = "Check that chromosome_name values in FASTA headers are unique",
             type = ANNOTATION,
-            priority = ValidationPriority.NORMAL)
+            priority = ValidationPriority.CRITICAL)
     public void validateChromosomeNameUnique(GFF3Annotation annotation, int line) throws ValidationException {
         String id = annotation.getAccession();
 
@@ -74,7 +74,7 @@ public class ChromosomeNameValidation implements Validation {
             rule = CHROMOSOME_OR_LINKAGE_GROUP_NAME_NOT_UNASSIGNED_RULE,
             description = "Check that chromosome and linkage group entries do not use unassigned chromosome names",
             type = ANNOTATION,
-            priority = ValidationPriority.HIGH)
+            priority = ValidationPriority.CRITICAL)
     public void validateChromosomeOrLinkageGroupNameAssigned(GFF3Annotation annotation, int line)
             throws ValidationException {
         Optional<FastaHeader> headerOpt = fastaHeaderFor(annotation.getAccession());
@@ -106,7 +106,7 @@ public class ChromosomeNameValidation implements Validation {
             rule = PLASMID_CHROMOSOME_NAME_FORMAT_RULE,
             description = "Check that plasmid entries use permitted plasmid names",
             type = ANNOTATION,
-            priority = ValidationPriority.HIGH)
+            priority = ValidationPriority.CRITICAL)
     public void validatePlasmidChromosomeNameFormat(GFF3Annotation annotation, int line) throws ValidationException {
         Optional<FastaHeader> headerOpt = fastaHeaderFor(annotation.getAccession());
         if (headerOpt.isEmpty()) {

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/ChromosomeNameValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/ChromosomeNameValidation.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.validation.builtin;
+
+import static uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.ControlledVocabularyUtils.ChromosomeType.*;
+import static uk.ac.ebi.embl.gff3tools.validation.meta.ValidationType.ANNOTATION;
+
+import java.util.*;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.ControlledVocabularyUtils;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
+import uk.ac.ebi.embl.gff3tools.validation.ValidationContext;
+import uk.ac.ebi.embl.gff3tools.validation.meta.*;
+
+@Slf4j
+@Gff3Validation(name = "CHROMOSOME_NAME")
+public class ChromosomeNameValidation implements Validation {
+    public static final String CHROMOSOME_NAME_UNIQUE_RULE = "CHROMOSOME_NAME_UNIQUE";
+    public static final String CHROMOSOME_OR_LINKAGE_GROUP_NAME_NOT_UNASSIGNED_RULE =
+            "CHROMOSOME_OR_LINKAGE_GROUP_NAME_NOT_UNASSIGNED";
+    public static final String PLASMID_CHROMOSOME_NAME_FORMAT_RULE = "PLASMID_CHROMOSOME_NAME_FORMAT";
+
+    private static final Set<String> UNASSIGNED_CHROMOSOME_NAME_WORDS = Set.of("unknown", "un", "unk");
+    private static final Pattern HISTORICAL_PLASMID_NAME_PATTERN = Pattern.compile(
+            "F\\d*" // F factor: 'F' or 'F' + digits
+                    + "|R[A-Za-z]*\\d+" // R / RP / RK factors: 'R' + optional letter(s) + digits, e.g. R1, RP4, RK2
+                    + "|Col[A-Za-z]+\\d*(-[A-Za-z0-9]+)?" // Col factors, e.g. ColE1, ColIb, ColIb-P9, ColV
+                    + "|Ti|Ri" // Ti / Ri plasmids
+                    + "|[Mm]egaplasmid"); // megaplasmid - allowed as a word or part of a word
+
+    @InjectContext
+    private ValidationContext context;
+
+    private final Map<String, String> chromosomeNameAccessions = new HashMap<>();
+
+    @ValidationMethod(
+            rule = CHROMOSOME_NAME_UNIQUE_RULE,
+            description = "Check that chromosome_name values in FASTA headers are unique",
+            type = ANNOTATION,
+            priority = ValidationPriority.NORMAL)
+    public void validateChromosomeNameUnique(GFF3Annotation annotation, int line) throws ValidationException {
+        String id = annotation.getAccession();
+
+        Optional<String> chromosomeName = fastaHeaderFor(id).flatMap(ChromosomeNameValidation::chromosomeName);
+        if (chromosomeName.isEmpty()) {
+            return;
+        }
+
+        String normalizedChromosomeName = chromosomeName.get();
+        String existingAccession = chromosomeNameAccessions.putIfAbsent(normalizedChromosomeName, id);
+        if (existingAccession != null && !existingAccession.equals(id)) {
+            log.warn("Duplicate chromosome_name '{}' found for accession {}", normalizedChromosomeName, id);
+            throw new ValidationException(
+                    CHROMOSOME_NAME_UNIQUE_RULE,
+                    line,
+                    "Duplicate chromosome_name '%s' found for FASTA headers with ids %s and %s"
+                            .formatted(normalizedChromosomeName, existingAccession, id));
+        }
+    }
+
+    @ValidationMethod(
+            rule = CHROMOSOME_OR_LINKAGE_GROUP_NAME_NOT_UNASSIGNED_RULE,
+            description = "Check that chromosome and linkage group entries do not use unassigned chromosome names",
+            type = ANNOTATION,
+            priority = ValidationPriority.HIGH)
+    public void validateChromosomeOrLinkageGroupNameAssigned(GFF3Annotation annotation, int line)
+            throws ValidationException {
+        Optional<FastaHeader> headerOpt = fastaHeaderFor(annotation.getAccession());
+        if (headerOpt.isEmpty()) {
+            return;
+        }
+
+        FastaHeader header = headerOpt.get();
+        if (!hasChromosomeType(header, Set.of(CHROMOSOME, LINKAGE_GROUP))) {
+            return;
+        }
+
+        Optional<String> chromosomeName = chromosomeName(header);
+        if (chromosomeName.isEmpty()) {
+            return;
+        }
+
+        String normalizedChromosomeName = chromosomeName.get();
+        if (isUnknownChromosomeName(normalizedChromosomeName)) {
+            throw new ValidationException(
+                    CHROMOSOME_OR_LINKAGE_GROUP_NAME_NOT_UNASSIGNED_RULE,
+                    line,
+                    "chromosome_name '%s' is not permitted for chromosome_type '%s'. Each unplaced sequence should be separate and without an assignment."
+                            .formatted(normalizedChromosomeName, header.getChromosomeType()));
+        }
+    }
+
+    @ValidationMethod(
+            rule = PLASMID_CHROMOSOME_NAME_FORMAT_RULE,
+            description = "Check that plasmid entries use permitted plasmid names",
+            type = ANNOTATION,
+            priority = ValidationPriority.HIGH)
+    public void validatePlasmidChromosomeNameFormat(GFF3Annotation annotation, int line) throws ValidationException {
+        Optional<FastaHeader> headerOpt = fastaHeaderFor(annotation.getAccession());
+        if (headerOpt.isEmpty()) {
+            return;
+        }
+
+        FastaHeader header = headerOpt.get();
+        if (!isPlasmid(header)) {
+            return;
+        }
+
+        Optional<String> chromosomeName = chromosomeName(header);
+        if (chromosomeName.isEmpty()) {
+            return;
+        }
+
+        String normalizedChromosomeName = chromosomeName.get();
+        if (!isValidPlasmidName(normalizedChromosomeName)) {
+            throw new ValidationException(
+                    PLASMID_CHROMOSOME_NAME_FORMAT_RULE,
+                    line,
+                    "chromosome_name '%s' is not a permitted plasmid name. Plasmid names must start with lower case 'p', except permitted historical names such as F1. Unnamed plasmid names such as unnamed or unnamed1 are allowed."
+                            .formatted(normalizedChromosomeName));
+        }
+    }
+
+    private Optional<FastaHeader> fastaHeaderFor(String id) {
+        return context.get(FastaHeaderProvider.class).getHeader(id);
+    }
+
+    private static Optional<String> chromosomeName(FastaHeader header) {
+        return Optional.ofNullable(header.getChromosomeName()).map(String::trim).filter(name -> !name.isEmpty());
+    }
+
+    private static boolean isPlasmid(FastaHeader header) {
+        return hasChromosomeType(header, Set.of(PLASMID));
+    }
+
+    private static boolean hasChromosomeType(
+            FastaHeader header, Set<ControlledVocabularyUtils.ChromosomeType> chromosomeTypes) {
+        return ControlledVocabularyUtils.normaliseChromosomeType(header)
+                .filter(chromosomeTypes::contains)
+                .isPresent();
+    }
+
+    private static boolean isUnknownChromosomeName(String chromosomeName) {
+        return "0".equals(chromosomeName)
+                || Arrays.stream(chromosomeName.split("[^A-Za-z0-9]+"))
+                        .map(word -> word.toLowerCase(Locale.ROOT))
+                        .anyMatch(UNASSIGNED_CHROMOSOME_NAME_WORDS::contains);
+    }
+
+    /** Checks conditions for valid name. The check for whether the forbidden plasmid name does not contain
+     * word plasmid except in case where it's part of "megaplasmid" is done in {@link FastaHeaderFormatValidation}
+     * @param chromosomeName name of the chromosome
+     * @return true if plasmid name is valid, false otherwise
+     */
+    private static boolean isValidPlasmidName(String chromosomeName) {
+        return chromosomeName.matches("unnamed\\d*") // unnamed allowed format
+                || HISTORICAL_PLASMID_NAME_PATTERN.matcher(chromosomeName).matches() // historical names
+                || chromosomeName.startsWith("p");
+    }
+}

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidation.java
@@ -53,9 +53,13 @@ public class FastaHeaderFormatValidation implements Validation {
             type = ANNOTATION,
             priority = ValidationPriority.HIGH)
     public void validate(GFF3Annotation annotation, int line) throws ValidationException {
-        FastaHeaderProvider fastaHeaderProvider = context.get(FastaHeaderProvider.class);
-        String id = annotation.getAccession();
+        FastaHeaderProvider fastaHeaderProvider =
+                context.contains(FastaHeaderProvider.class) ? context.get(FastaHeaderProvider.class) : null;
+        if (fastaHeaderProvider == null) {
+            return;
+        }
 
+        String id = annotation.getAccession();
         log.debug("Validating FASTA header for accession {}", id);
         Optional<FastaHeader> header = fastaHeaderProvider.getHeader(id);
 

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidation.java
@@ -51,7 +51,7 @@ public class FastaHeaderFormatValidation implements Validation {
             rule = VALIDATION_RULE,
             description = "Check if the fields in the FASTA Header are populated correctly",
             type = ANNOTATION,
-            priority = ValidationPriority.HIGH)
+            priority = ValidationPriority.CRITICAL)
     public void validate(GFF3Annotation annotation, int line) throws ValidationException {
         FastaHeaderProvider fastaHeaderProvider =
                 context.contains(FastaHeaderProvider.class) ? context.get(FastaHeaderProvider.class) : null;

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidation.java
@@ -106,10 +106,9 @@ public class FastaHeaderFormatValidation implements Validation {
      *       </li>
      *     </ul>
      *   </li>
-     *   <li><b>Optional field combinations:</b> chromosome_type requires chromosome_name, and
-     *     chromosome_location requires both chromosome_name and chromosome_type. The only valid
-     *     combinations are: none present, chromosome_name only, or chromosome_name + chromosome_type
-     *     (with chromosome_location optional in that last case).</li>
+     *   <li><b>Optional field combinations:</b> chromosome_type and chromosome_location may only be
+     *     present when chromosome_name, chromosome_type and chromosome_location are all present. The
+     *     only valid combinations are: none present, chromosome_name only, or all three present.</li>
      * </ul>
      *
      * @param header the {@link FastaHeader} to validate
@@ -189,20 +188,19 @@ public class FastaHeaderFormatValidation implements Validation {
     /**
      * Validates that the optional chromosome fields appear only in one of the allowed combinations.
      *
-     * <p>Mirrors the ENA Chromosome List File column structure (see the <a
+     * <p>Per the team decision (2026-07), chromosome_location is a mandatory attribute whenever a
+     * chromosome is described, with {@code Nuclear} available as an explicit value for the
+     * nuclear/cytoplasmic default (see the <a
      * href="https://ena-docs.readthedocs.io/en/latest/submit/fileprep/assembly.html">ENA assembly
-     * submission docs</a>): chromosome_name and chromosome_type are mandatory together to describe a
-     * chromosome list entry, and chromosome_location is an independently optional fourth column on
-     * top of that entry (a chromosome is assumed nuclear/cytoplasmic when it is absent). Valid
-     * combinations are:</p>
+     * submission docs</a>). Valid combinations are:</p>
      * <ul>
      *   <li>none present &rarr; unplaced contig</li>
      *   <li>chromosome_name only &rarr; unlocalized</li>
-     *   <li>chromosome_name and chromosome_type, chromosome_location optional &rarr; chromosome</li>
+     *   <li>chromosome_name, chromosome_type and chromosome_location all present &rarr; chromosome</li>
      * </ul>
      *
-     * <p>Equivalently: chromosome_type requires chromosome_name, and chromosome_location requires
-     * both chromosome_name and chromosome_type. Any other combination is rejected.</p>
+     * <p>Equivalently: whenever chromosome_type or chromosome_location is present, all three fields
+     * must be present. Any other combination is rejected.</p>
      *
      * @param header the {@link FastaHeader} to inspect
      * @param errors the error list to append to when the combination is invalid
@@ -216,12 +214,10 @@ public class FastaHeaderFormatValidation implements Validation {
         boolean hasType = !isBlank(header.getChromosomeType());
         boolean hasLocation = !isBlank(header.getChromosomeLocation());
 
-        boolean validCombination = (!hasType && !hasLocation) || (hasName && hasType);
-
-        if (!validCombination) {
-            errors.add("invalid combination of optional chromosome fields - chromosome_type requires "
-                    + "chromosome_name, and chromosome_location requires chromosome_name and chromosome_type "
-                    + "(allowed combinations: none, chromosome_name only, chromosome_name + chromosome_type, "
+        if ((hasType || hasLocation) && !(hasName && hasType && hasLocation)) {
+            errors.add("invalid combination of optional chromosome fields - chromosome_type and "
+                    + "chromosome_location may only be present when chromosome_name, chromosome_type and "
+                    + "chromosome_location are all present (allowed combinations: none, chromosome_name only, "
                     + "or all three)");
         }
     }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidation.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.validation.builtin;
+
+import static uk.ac.ebi.embl.gff3tools.validation.meta.ValidationType.ANNOTATION;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.ControlledVocabularyUtils;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
+import uk.ac.ebi.embl.gff3tools.validation.ValidationContext;
+import uk.ac.ebi.embl.gff3tools.validation.meta.*;
+
+/**
+ * Validates FASTA header metadata associated with GFF3 annotations.
+ *
+ * <p>The validation is performed by resolving the annotation accession against the
+ * {@link FastaHeaderProvider}. If a matching FASTA header is available, this class
+ * checks required header fields and a small set of controlled-value and formatting
+ * constraints for topology and chromosome-related attributes.</p>
+ */
+@Slf4j
+@Gff3Validation(name = "FASTA_HEADER")
+public class FastaHeaderFormatValidation implements Validation {
+    public static final String VALIDATION_RULE = "FASTA_HEADER_SYNTAX_VALIDATION";
+
+    private static final List<String> FORBIDDEN_CHROMOSOME_NAME_PARTS =
+            List.of("chr", "chrm", "chrom", "chromosome", "linkage group", "linkage-group", "linkage_group");
+    private static final Pattern CHROMOSOME_NAME_PATTERN = Pattern.compile("^([A-Za-z0-9]){1}([A-Za-z0-9_\\.]|-)*$");
+    private static final int CHROMOSOME_NAME_LENGTH = 33;
+
+    @InjectContext
+    private ValidationContext context;
+
+    @ValidationMethod(
+            rule = VALIDATION_RULE,
+            description = "Check if the fields in the FASTA Header are populated correctly",
+            type = ANNOTATION,
+            priority = ValidationPriority.HIGH)
+    public void validate(GFF3Annotation annotation, int line) throws ValidationException {
+        FastaHeaderProvider fastaHeaderProvider = context.get(FastaHeaderProvider.class);
+        String id = annotation.getAccession();
+
+        log.debug("Validating FASTA header for accession {}", id);
+        Optional<FastaHeader> header = fastaHeaderProvider.getHeader(id);
+
+        if (header.isEmpty()) {
+            log.warn("No FASTA header found for accession {}", id);
+            return;
+        }
+
+        List<String> errors = this.validate(header.get());
+        if (!errors.isEmpty()) {
+            log.warn("FASTA header validation failed for accession {} with {} violation(s)", id, errors.size());
+
+            throw new ValidationException(
+                    "FASTA_HEADER_SYNTAX_VALIDATION",
+                    line,
+                    "Fasta header with id " + id + " has the following syntax violations : " + String.join(",", errors)
+                            + ".");
+        }
+    }
+
+    /**
+     * Validates the given {@link FastaHeader} instance against mandatory fields,
+     * allowed values, and format constraints.
+     *
+     * <p>Validation rules include:</p>
+     * <ul>
+     *   <li><b>Mandatory fields:</b>
+     *     <ul>
+     *       <li>description must be non-null and non-blank</li>
+     *       <li>molecule_type must be one of the allowed mol_type qualifier values</li>
+     *       <li>topology must be either "linear" or "circular"</li>
+     *     </ul>
+     *   </li>
+     *   <li><b>Optional fields (if present):</b>
+     *     <ul>
+     *       <li>chromosome_type must be one of the allowed values</li>
+     *       <li>chromosome_location must match one of the predefined values (case-sensitive)</li>
+     *       <li>chromosome_name must:
+     *         <ul>
+     *           <li>match the required pattern</li>
+     *           <li>be shorter than 33 characters</li>
+     *           <li>not contain forbidden substrings (case-insensitive)</li>
+     *         </ul>
+     *       </li>
+     *     </ul>
+     *   </li>
+     * </ul>
+     *
+     * @param header the {@link FastaHeader} to validate
+     * @return a list of validation error messages; empty if the input is valid
+     */
+    protected static List<String> validate(FastaHeader header) {
+        List<String> errors = new ArrayList<>();
+
+        if (header == null) {
+            errors.add("FastaHeader must not be null");
+            return errors;
+        }
+
+        // --- Mandatory fields ---
+        if (isBlank(header.getDescription())) {
+            errors.add("description is mandatory");
+        }
+
+        if (isBlank(header.getMoleculeType())) {
+            errors.add("molecule_type is mandatory");
+        } else if (ControlledVocabularyUtils.normaliseMolType(header).isEmpty()) {
+            errors.add("molecule_type must be one of the allowed mol_type qualifier values");
+        }
+
+        if (isBlank(header.getTopology())) {
+            errors.add("topology is mandatory");
+        } else if (ControlledVocabularyUtils.normaliseTopology(header).isEmpty()) {
+            errors.add("topology must be 'linear' or 'circular'");
+        }
+
+        // --- Optional: chromosome_type ---
+        if (!isBlank(header.getChromosomeType())) {
+            if (ControlledVocabularyUtils.normaliseChromosomeType(header).isEmpty()) {
+                errors.add("invalid chromosome_type - see allowed values list");
+            }
+        }
+
+        // --- Optional: chromosome_location ---
+        if (!isBlank(header.getChromosomeLocation())) {
+            if (ControlledVocabularyUtils.normaliseChromosomeLocation(header).isEmpty()) {
+                errors.add("invalid chromosome_location - see allowed values list");
+            }
+        }
+
+        // --- Optional: chromosome_name ---
+        if (!isBlank(header.getChromosomeName())) {
+            String name = header.getChromosomeName();
+
+            if (!CHROMOSOME_NAME_PATTERN.matcher(name).matches()) {
+                errors.add("invalid chromosome_name format");
+            }
+
+            if (name.length() >= CHROMOSOME_NAME_LENGTH) {
+                errors.add("chromosome_name must be shorter than " + CHROMOSOME_NAME_LENGTH + " characters");
+            }
+
+            String lower = name.toLowerCase();
+            for (String forbidden : FORBIDDEN_CHROMOSOME_NAME_PARTS) {
+                if (lower.contains(forbidden)) {
+                    errors.add("chromosome_name contains forbidden term: " + forbidden);
+                    break;
+                }
+            }
+
+            if (containsForbiddenPlasmidWord(lower)) {
+                errors.add(
+                        "chromosome_name contains forbidden term which is only allowed as part of word 'megaplasmid': plasmid");
+            }
+        }
+
+        return errors;
+    }
+
+    // "plasmid" is forbidden unless the occurrence is part of the permitted word "megaplasmid".
+    private static boolean containsForbiddenPlasmidWord(String chromosomeName) {
+        String normalizedName = chromosomeName.toLowerCase(Locale.ROOT);
+        int plasmidIndex = normalizedName.indexOf("plasmid");
+
+        while (plasmidIndex >= 0) {
+            if (!normalizedName.startsWith("megaplasmid", plasmidIndex - "mega".length())) {
+                return true;
+            }
+            plasmidIndex = normalizedName.indexOf("plasmid", plasmidIndex + 1);
+        }
+
+        return false;
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
+    }
+}

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidation.java
@@ -106,9 +106,10 @@ public class FastaHeaderFormatValidation implements Validation {
      *       </li>
      *     </ul>
      *   </li>
-     *   <li><b>Optional field combinations:</b> chromosome_type and chromosome_location may only be
-     *     present when chromosome_name, chromosome_type and chromosome_location are all present. The
-     *     only valid combinations are: none present, chromosome_name only, or all three present.</li>
+     *   <li><b>Optional field combinations:</b> chromosome_type requires chromosome_name, and
+     *     chromosome_location requires both chromosome_name and chromosome_type. The only valid
+     *     combinations are: none present, chromosome_name only, or chromosome_name + chromosome_type
+     *     (with chromosome_location optional in that last case).</li>
      * </ul>
      *
      * @param header the {@link FastaHeader} to validate
@@ -188,15 +189,20 @@ public class FastaHeaderFormatValidation implements Validation {
     /**
      * Validates that the optional chromosome fields appear only in one of the allowed combinations.
      *
-     * <p>Only three combinations are valid:</p>
+     * <p>Mirrors the ENA Chromosome List File column structure (see the <a
+     * href="https://ena-docs.readthedocs.io/en/latest/submit/fileprep/assembly.html">ENA assembly
+     * submission docs</a>): chromosome_name and chromosome_type are mandatory together to describe a
+     * chromosome list entry, and chromosome_location is an independently optional fourth column on
+     * top of that entry (a chromosome is assumed nuclear/cytoplasmic when it is absent). Valid
+     * combinations are:</p>
      * <ul>
      *   <li>none present &rarr; unplaced contig</li>
      *   <li>chromosome_name only &rarr; unlocalized</li>
-     *   <li>chromosome_name, chromosome_type and chromosome_location all present &rarr; chromosome</li>
+     *   <li>chromosome_name and chromosome_type, chromosome_location optional &rarr; chromosome</li>
      * </ul>
      *
-     * <p>Equivalently: whenever chromosome_type or chromosome_location is present, all three fields
-     * must be present. Any other combination is rejected.</p>
+     * <p>Equivalently: chromosome_type requires chromosome_name, and chromosome_location requires
+     * both chromosome_name and chromosome_type. Any other combination is rejected.</p>
      *
      * @param header the {@link FastaHeader} to inspect
      * @param errors the error list to append to when the combination is invalid
@@ -210,10 +216,12 @@ public class FastaHeaderFormatValidation implements Validation {
         boolean hasType = !isBlank(header.getChromosomeType());
         boolean hasLocation = !isBlank(header.getChromosomeLocation());
 
-        if ((hasType || hasLocation) && !(hasName && hasType && hasLocation)) {
-            errors.add("invalid combination of optional chromosome fields - chromosome_type and "
-                    + "chromosome_location may only be present when chromosome_name, chromosome_type and "
-                    + "chromosome_location are all present (allowed combinations: none, chromosome_name only, "
+        boolean validCombination = (!hasType && !hasLocation) || (hasName && hasType);
+
+        if (!validCombination) {
+            errors.add("invalid combination of optional chromosome fields - chromosome_type requires "
+                    + "chromosome_name, and chromosome_location requires chromosome_name and chromosome_type "
+                    + "(allowed combinations: none, chromosome_name only, chromosome_name + chromosome_type, "
                     + "or all three)");
         }
     }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidation.java
@@ -106,6 +106,9 @@ public class FastaHeaderFormatValidation implements Validation {
      *       </li>
      *     </ul>
      *   </li>
+     *   <li><b>Optional field combinations:</b> chromosome_type and chromosome_location may only be
+     *     present when chromosome_name, chromosome_type and chromosome_location are all present. The
+     *     only valid combinations are: none present, chromosome_name only, or all three present.</li>
      * </ul>
      *
      * @param header the {@link FastaHeader} to validate
@@ -176,7 +179,43 @@ public class FastaHeaderFormatValidation implements Validation {
             }
         }
 
+        // --- Optional fields: allowed combinations ---
+        validateChromosomeCombination(header, errors);
+
         return errors;
+    }
+
+    /**
+     * Validates that the optional chromosome fields appear only in one of the allowed combinations.
+     *
+     * <p>Only three combinations are valid:</p>
+     * <ul>
+     *   <li>none present &rarr; unplaced contig</li>
+     *   <li>chromosome_name only &rarr; unlocalized</li>
+     *   <li>chromosome_name, chromosome_type and chromosome_location all present &rarr; chromosome</li>
+     * </ul>
+     *
+     * <p>Equivalently: whenever chromosome_type or chromosome_location is present, all three fields
+     * must be present. Any other combination is rejected.</p>
+     *
+     * @param header the {@link FastaHeader} to inspect
+     * @param errors the error list to append to when the combination is invalid
+     */
+    private static void validateChromosomeCombination(FastaHeader header, List<String> errors) {
+        if (header == null) {
+            return;
+        }
+
+        boolean hasName = !isBlank(header.getChromosomeName());
+        boolean hasType = !isBlank(header.getChromosomeType());
+        boolean hasLocation = !isBlank(header.getChromosomeLocation());
+
+        if ((hasType || hasLocation) && !(hasName && hasType && hasLocation)) {
+            errors.add("invalid combination of optional chromosome fields - chromosome_type and "
+                    + "chromosome_location may only be present when chromosome_name, chromosome_type and "
+                    + "chromosome_location are all present (allowed combinations: none, chromosome_name only, "
+                    + "or all three)");
+        }
     }
 
     // "plasmid" is forbidden unless the occurrence is part of the permitted word "megaplasmid".

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidation.java
@@ -189,8 +189,8 @@ public class FastaHeaderFormatValidation implements Validation {
      * Validates that the optional chromosome fields appear only in one of the allowed combinations.
      *
      * <p>Per the team decision (2026-07), chromosome_location is a mandatory attribute whenever a
-     * chromosome is described, with {@code Nuclear} available as an explicit value for the
-     * nuclear/cytoplasmic default (see the <a
+     * chromosome is described, with {@code Nucleus} (eukaryotic) and {@code Cytoplasm}
+     * (prokaryotic/plasmid) available as explicit values for the default location (see the <a
      * href="https://ena-docs.readthedocs.io/en/latest/submit/fileprep/assembly.html">ENA assembly
      * submission docs</a>). Valid combinations are:</p>
      * <ul>

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderMappingValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderMappingValidation.java
@@ -10,15 +10,12 @@
  */
 package uk.ac.ebi.embl.gff3tools.validation.builtin;
 
-import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
 import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
 import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
 import uk.ac.ebi.embl.gff3tools.validation.ValidationContext;
-import uk.ac.ebi.embl.gff3tools.validation.meta.ExitMethod;
 import uk.ac.ebi.embl.gff3tools.validation.meta.Gff3Validation;
 import uk.ac.ebi.embl.gff3tools.validation.meta.InjectContext;
 import uk.ac.ebi.embl.gff3tools.validation.meta.Validation;
@@ -40,8 +37,6 @@ public class FastaHeaderMappingValidation implements Validation {
     @InjectContext
     private ValidationContext context;
 
-    private final Set<String> validatedAccessions = new HashSet<>();
-
     @ValidationMethod(
             rule = RULE_FASTA_HEADER_MAPPING,
             description =
@@ -55,23 +50,13 @@ public class FastaHeaderMappingValidation implements Validation {
         }
 
         String accession = annotation.getAccession();
-        if (!validatedAccessions.add(accession)) {
-            return;
-        }
-
         Optional<FastaHeader> header = headerProvider.getHeader(accession);
         if (header.isEmpty()) {
-            validatedAccessions.remove(accession);
             throw new ValidationException(RULE_FASTA_HEADER_MAPPING, line, NO_HEADER_MESSAGE.formatted(accession));
         }
     }
 
     private FastaHeaderProvider registeredHeaderProvider() {
         return context.contains(FastaHeaderProvider.class) ? context.get(FastaHeaderProvider.class) : null;
-    }
-
-    @ExitMethod
-    public void clear() {
-        validatedAccessions.clear();
     }
 }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderMappingValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderMappingValidation.java
@@ -14,7 +14,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
-import uk.ac.ebi.embl.gff3tools.gff3.GFF3Feature;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
 import uk.ac.ebi.embl.gff3tools.validation.ValidationContext;
@@ -29,13 +29,13 @@ import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationType;
 @Gff3Validation(
         name = "FASTA_HEADER_MAPPING",
         description =
-                "Validates that every feature accession maps to a FASTA header when a FASTA header provider is registered")
+                "Validates that every annotation accession maps to a FASTA header when a FASTA header provider is registered")
 public class FastaHeaderMappingValidation implements Validation {
 
     private static final String RULE_FASTA_HEADER_MAPPING = "FASTA_HEADER_MAPPING";
     private static final String NO_HEADER_MESSAGE =
             "No FASTA header could be resolved for accession \"%s\". A FASTA header provider is registered but does "
-                    + "not supply a header for this feature.";
+                    + "not supply a header for this annotation.";
 
     @InjectContext
     private ValidationContext context;
@@ -44,16 +44,17 @@ public class FastaHeaderMappingValidation implements Validation {
 
     @ValidationMethod(
             rule = RULE_FASTA_HEADER_MAPPING,
-            description = "Every feature accession must map to a FASTA header when a FASTA header provider is registered",
-            type = ValidationType.FEATURE,
+            description =
+                    "Every annotation accession must map to a FASTA header when a FASTA header provider is registered",
+            type = ValidationType.ANNOTATION,
             priority = ValidationPriority.CRITICAL)
-    public void validateFastaHeaderMapping(GFF3Feature feature, int line) throws ValidationException {
+    public void validateFastaHeaderMapping(GFF3Annotation annotation, int line) throws ValidationException {
         FastaHeaderProvider headerProvider = registeredHeaderProvider();
         if (headerProvider == null) {
             return;
         }
 
-        String accession = feature.accession();
+        String accession = annotation.getAccession();
         if (!validatedAccessions.add(accession)) {
             return;
         }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderMappingValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderMappingValidation.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.validation.builtin;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Feature;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
+import uk.ac.ebi.embl.gff3tools.validation.ValidationContext;
+import uk.ac.ebi.embl.gff3tools.validation.meta.ExitMethod;
+import uk.ac.ebi.embl.gff3tools.validation.meta.Gff3Validation;
+import uk.ac.ebi.embl.gff3tools.validation.meta.InjectContext;
+import uk.ac.ebi.embl.gff3tools.validation.meta.Validation;
+import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationMethod;
+import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationPriority;
+import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationType;
+
+@Gff3Validation(
+        name = "FASTA_HEADER_MAPPING",
+        description =
+                "Validates that every feature accession maps to a FASTA header when a FASTA header provider is registered")
+public class FastaHeaderMappingValidation implements Validation {
+
+    private static final String RULE_FASTA_HEADER_MAPPING = "FASTA_HEADER_MAPPING";
+    private static final String NO_HEADER_MESSAGE =
+            "No FASTA header could be resolved for accession \"%s\". A FASTA header provider is registered but does "
+                    + "not supply a header for this feature.";
+
+    @InjectContext
+    private ValidationContext context;
+
+    private final Set<String> validatedAccessions = new HashSet<>();
+
+    @ValidationMethod(
+            rule = RULE_FASTA_HEADER_MAPPING,
+            description = "Every feature accession must map to a FASTA header when a FASTA header provider is registered",
+            type = ValidationType.FEATURE,
+            priority = ValidationPriority.CRITICAL)
+    public void validateFastaHeaderMapping(GFF3Feature feature, int line) throws ValidationException {
+        FastaHeaderProvider headerProvider = registeredHeaderProvider();
+        if (headerProvider == null) {
+            return;
+        }
+
+        String accession = feature.accession();
+        if (!validatedAccessions.add(accession)) {
+            return;
+        }
+
+        Optional<FastaHeader> header = headerProvider.getHeader(accession);
+        if (header.isEmpty()) {
+            validatedAccessions.remove(accession);
+            throw new ValidationException(RULE_FASTA_HEADER_MAPPING, line, NO_HEADER_MESSAGE.formatted(accession));
+        }
+    }
+
+    private FastaHeaderProvider registeredHeaderProvider() {
+        return context.contains(FastaHeaderProvider.class) ? context.get(FastaHeaderProvider.class) : null;
+    }
+
+    @ExitMethod
+    public void clear() {
+        validatedAccessions.clear();
+    }
+}

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderMappingValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderMappingValidation.java
@@ -44,7 +44,8 @@ public class FastaHeaderMappingValidation implements Validation {
             type = ValidationType.ANNOTATION,
             priority = ValidationPriority.CRITICAL)
     public void validateFastaHeaderMapping(GFF3Annotation annotation, int line) throws ValidationException {
-        FastaHeaderProvider headerProvider = registeredHeaderProvider();
+        FastaHeaderProvider headerProvider =
+                context.contains(FastaHeaderProvider.class) ? context.get(FastaHeaderProvider.class) : null;
         if (headerProvider == null) {
             return;
         }
@@ -54,9 +55,5 @@ public class FastaHeaderMappingValidation implements Validation {
         if (header.isEmpty()) {
             throw new ValidationException(RULE_FASTA_HEADER_MAPPING, line, NO_HEADER_MESSAGE.formatted(accession));
         }
-    }
-
-    private FastaHeaderProvider registeredHeaderProvider() {
-        return context.contains(FastaHeaderProvider.class) ? context.get(FastaHeaderProvider.class) : null;
     }
 }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/MoleculeTypeValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/MoleculeTypeValidation.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.validation.builtin;
+
+import static uk.ac.ebi.embl.gff3tools.validation.meta.ValidationType.ANNOTATION;
+
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Feature;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.ControlledVocabularyUtils;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
+import uk.ac.ebi.embl.gff3tools.utils.OntologyClient;
+import uk.ac.ebi.embl.gff3tools.utils.OntologyTerm;
+import uk.ac.ebi.embl.gff3tools.validation.ValidationContext;
+import uk.ac.ebi.embl.gff3tools.validation.meta.*;
+
+@Slf4j
+@Gff3Validation(name = "MOLECULE_TYPE_FEATURE")
+public class MoleculeTypeValidation implements Validation {
+    public static final String REQUIRED_FEATURE_RULE = "MOLECULE_TYPE_REQUIRED_FEATURE";
+    public static final String MRNA_CDS_COMPLEMENT_RULE = "MRNA_CDS_COMPLEMENT";
+
+    private static final Map<ControlledVocabularyUtils.MolType, OntologyTerm> REQUIRED_FEATURE_BY_MOLECULE_TYPE =
+            Map.of(
+                    ControlledVocabularyUtils.MolType.RRNA,
+                    OntologyTerm.RRNA,
+                    ControlledVocabularyUtils.MolType.TRNA,
+                    OntologyTerm.TRNA);
+
+    @InjectContext
+    private ValidationContext context;
+
+    @ValidationMethod(
+            rule = REQUIRED_FEATURE_RULE,
+            description = "Check that molecule types with mandatory features contain those features",
+            type = ANNOTATION,
+            priority = ValidationPriority.HIGH)
+    public void validateRequiredFeature(GFF3Annotation annotation, int line) throws ValidationException {
+        Optional<ControlledVocabularyUtils.MolType> moleculeType = getMoleculeType(annotation.getAccession());
+        if (moleculeType.isEmpty()) {
+            return;
+        }
+
+        OntologyTerm requiredFeatureParent = REQUIRED_FEATURE_BY_MOLECULE_TYPE.get(moleculeType.get());
+        if (requiredFeatureParent == null) {
+            return;
+        }
+
+        OntologyClient ontologyClient = context.get(OntologyClient.class);
+        for (final GFF3Feature feature : annotation.getFeatures()) {
+            Optional<String> soIdOpt = ontologyClient.findTermByNameOrSynonym(feature.getName());
+            if (soIdOpt.isEmpty()) continue;
+            String soId = soIdOpt.get();
+            if (ontologyClient.isSelfOrDescendantOf(soId, requiredFeatureParent.ID)) {
+                return;
+            }
+        }
+
+        throw new ValidationException(
+                REQUIRED_FEATURE_RULE,
+                line,
+                "Feature %s is required when molecule type is %s."
+                        .formatted(requiredFeatureParent, moleculeType.get()));
+    }
+
+    @ValidationMethod(
+            rule = MRNA_CDS_COMPLEMENT_RULE,
+            description = "Check that CDS features on mRNA entries do not use complement locations",
+            type = ANNOTATION,
+            priority = ValidationPriority.HIGH)
+    public void validateMrnaCdsComplement(GFF3Annotation annotation, int line) throws ValidationException {
+        if (!isMRNA(annotation.getAccession())) {
+            return;
+        }
+
+        for (final GFF3Feature feature : annotation.getFeatures()) {
+            if (isCds(feature) && feature.isComplement()) {
+                throw new ValidationException(
+                        MRNA_CDS_COMPLEMENT_RULE,
+                        line,
+                        "Complement locations are not permitted in CDS features on mRNA entries.");
+            }
+        }
+    }
+
+    private boolean isCds(GFF3Feature feature) {
+        OntologyClient ontologyClient = context.get(OntologyClient.class);
+        String featureName = feature.getName();
+        Optional<String> soIdOpt = ontologyClient.findTermByNameOrSynonym(featureName);
+        if (soIdOpt.isEmpty()) {
+            return false;
+        }
+
+        String soId = soIdOpt.get();
+
+        return soId.equals(OntologyTerm.CDS.ID) || ontologyClient.isSelfOrDescendantOf(soId, OntologyTerm.CDS.ID);
+    }
+
+    private boolean isMRNA(String accession) {
+        Optional<ControlledVocabularyUtils.MolType> molTypeOpt = getMoleculeType(accession);
+        return molTypeOpt
+                .filter(molType -> molType == ControlledVocabularyUtils.MolType.MRNA)
+                .isPresent();
+    }
+
+    private Optional<ControlledVocabularyUtils.MolType> getMoleculeType(String accession) {
+        FastaHeaderProvider fastaHeaderProvider = context.get(FastaHeaderProvider.class);
+
+        log.debug("Validating molecule type from FASTA header for accession {}", accession);
+        Optional<FastaHeader> header = fastaHeaderProvider.getHeader(accession);
+        if (header.isEmpty()) {
+            log.warn("No FASTA header found for accession {}", accession);
+            return Optional.empty();
+        }
+
+        return ControlledVocabularyUtils.normaliseMolType(header.get());
+    }
+}

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/MoleculeTypeValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/MoleculeTypeValidation.java
@@ -116,7 +116,11 @@ public class MoleculeTypeValidation implements Validation {
     }
 
     private Optional<ControlledVocabularyUtils.MolType> getMoleculeType(String accession) {
-        FastaHeaderProvider fastaHeaderProvider = context.get(FastaHeaderProvider.class);
+        FastaHeaderProvider fastaHeaderProvider =
+                context.contains(FastaHeaderProvider.class) ? context.get(FastaHeaderProvider.class) : null;
+        if (fastaHeaderProvider == null) {
+            return Optional.empty();
+        }
 
         log.debug("Validating molecule type from FASTA header for accession {}", accession);
         Optional<FastaHeader> header = fastaHeaderProvider.getHeader(accession);

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/MoleculeTypeValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/MoleculeTypeValidation.java
@@ -46,7 +46,7 @@ public class MoleculeTypeValidation implements Validation {
             rule = REQUIRED_FEATURE_RULE,
             description = "Check that molecule types with mandatory features contain those features",
             type = ANNOTATION,
-            priority = ValidationPriority.HIGH)
+            priority = ValidationPriority.CRITICAL)
     public void validateRequiredFeature(GFF3Annotation annotation, int line) throws ValidationException {
         Optional<ControlledVocabularyUtils.MolType> moleculeType = getMoleculeType(annotation.getAccession());
         if (moleculeType.isEmpty()) {
@@ -79,7 +79,7 @@ public class MoleculeTypeValidation implements Validation {
             rule = MRNA_CDS_COMPLEMENT_RULE,
             description = "Check that CDS features on mRNA entries do not use complement locations",
             type = ANNOTATION,
-            priority = ValidationPriority.HIGH)
+            priority = ValidationPriority.CRITICAL)
     public void validateMrnaCdsComplement(GFF3Annotation annotation, int line) throws ValidationException {
         if (!isMRNA(annotation.getAccession())) {
             return;

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/ChromosomeNameFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/ChromosomeNameFix.java
@@ -47,7 +47,8 @@ public class ChromosomeNameFix implements Fix {
         String accession = annotation.getAccession();
         Optional<FastaHeader> headerOpt = context.get(FastaHeaderProvider.class).getHeader(accession);
         if (headerOpt.isEmpty()) {
-            throw new IllegalStateException("No FASTA header found for accession " + accession);
+            log.warn("No FASTA header found for accession {}", accession);
+            return;
         }
 
         FastaHeader header = headerOpt.get();

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/ChromosomeNameFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/ChromosomeNameFix.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.validation.fix;
+
+import static uk.ac.ebi.embl.gff3tools.validation.meta.ValidationType.ANNOTATION;
+
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
+import uk.ac.ebi.embl.gff3tools.validation.ValidationContext;
+import uk.ac.ebi.embl.gff3tools.validation.meta.Fix;
+import uk.ac.ebi.embl.gff3tools.validation.meta.FixMethod;
+import uk.ac.ebi.embl.gff3tools.validation.meta.Gff3Fix;
+import uk.ac.ebi.embl.gff3tools.validation.meta.InjectContext;
+
+@Slf4j
+@Gff3Fix(
+        name = "CHROMOSOME_NAME",
+        description =
+                "Normalises the chromosome_name of the FASTA header registered for the annotation's accession by stripping whitespace, illegal characters and chromosome/linkage-group/plasmid keywords.")
+public class ChromosomeNameFix implements Fix {
+
+    @InjectContext
+    private ValidationContext context;
+
+    @FixMethod(
+            rule = "CHROMOSOME_NAME",
+            description =
+                    "Normalises the chromosome_name of the FASTA header registered for the annotation's accession by stripping whitespace, illegal characters and chromosome/linkage-group/plasmid keywords.",
+            type = ANNOTATION)
+    public void fix(GFF3Annotation annotation, int line) {
+        // No FASTA header source registered for this run -> nothing to fix.
+        if (!context.contains(FastaHeaderProvider.class)) {
+            return;
+        }
+
+        String accession = annotation.getAccession();
+        Optional<FastaHeader> headerOpt = context.get(FastaHeaderProvider.class).getHeader(accession);
+        if (headerOpt.isEmpty()) {
+            log.warn("No FASTA header found for accession {}", accession);
+            return;
+        }
+
+        FastaHeader header = headerOpt.get();
+        String chromosomeName = header.getChromosomeName();
+        // chromosome_name is optional; nothing to normalise when it is absent.
+        if (chromosomeName == null) {
+            return;
+        }
+
+        String fixed = normalise(chromosomeName);
+        if (!fixed.equals(chromosomeName)) {
+            log.info(
+                    "Normalising chromosome_name for accession {} from '{}' to '{}' at line: {}",
+                    accession,
+                    chromosomeName,
+                    fixed,
+                    line);
+            header.setChromosomeName(fixed);
+        }
+    }
+
+    /**
+     * Strips, from the chromosome name (in order):
+     *
+     * <ul>
+     *   <li>all whitespace,
+     *   <li>the keywords {@code chromosome}, {@code chrom}, {@code chrm}, {@code chr},
+     *       {@code linkage-group} / {@code linkage group} and {@code plasmid} (case-insensitive),
+     *       leaving the {@code plasmid} in {@code megaplasmid} intact,
+     *   <li>the characters {@code \ / | = ;}, each replaced with {@code _},
+     *   <li>duplicate {@code _} runs (collapsed to a single {@code _}),
+     *   <li>leading and trailing {@code _} characters.
+     * </ul>
+     */
+    private String normalise(String chromosomeName) {
+        String value = chromosomeName;
+
+        // Remove all whitespace. This also turns "linkage group" into "linkagegroup".
+        value = value.replaceAll("\\s", "");
+
+        // Remove keywords (case-insensitive), longest first so "chromosome"/"chrom" are not
+        // partially consumed by the shorter "chr".
+        value = value.replaceAll("(?i)chromosome", "");
+        value = value.replaceAll("(?i)chrom", "");
+        value = value.replaceAll("(?i)chrm", "");
+        value = value.replaceAll("(?i)chr", "");
+        value = value.replaceAll("(?i)linkage-group", "");
+        value = value.replaceAll("(?i)linkagegroup", "");
+        // Drop "plasmid" unless it is part of "megaplasmid".
+        value = value.replaceAll("(?i)(?<!mega)plasmid", "");
+
+        // Replace illegal characters with underscores.
+        value = value.replaceAll("[\\\\/|=;]", "_");
+
+        // Collapse duplicate underscore runs, then trim leading/trailing underscores.
+        value = value.replaceAll("_+", "_");
+        value = value.replaceAll("^_+", "");
+        value = value.replaceAll("_+$", "");
+
+        return value;
+    }
+}

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/ChromosomeNameFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/ChromosomeNameFix.java
@@ -47,8 +47,7 @@ public class ChromosomeNameFix implements Fix {
         String accession = annotation.getAccession();
         Optional<FastaHeader> headerOpt = context.get(FastaHeaderProvider.class).getHeader(accession);
         if (headerOpt.isEmpty()) {
-            log.warn("No FASTA header found for accession {}", accession);
-            return;
+            throw new IllegalStateException("No FASTA header found for accession " + accession);
         }
 
         FastaHeader header = headerOpt.get();

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/ChromosomeNameFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/ChromosomeNameFix.java
@@ -22,6 +22,7 @@ import uk.ac.ebi.embl.gff3tools.validation.meta.Fix;
 import uk.ac.ebi.embl.gff3tools.validation.meta.FixMethod;
 import uk.ac.ebi.embl.gff3tools.validation.meta.Gff3Fix;
 import uk.ac.ebi.embl.gff3tools.validation.meta.InjectContext;
+import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationPriority;
 
 @Slf4j
 @Gff3Fix(
@@ -37,7 +38,8 @@ public class ChromosomeNameFix implements Fix {
             rule = "CHROMOSOME_NAME",
             description =
                     "Normalises the chromosome_name of the FASTA header registered for the annotation's accession by stripping whitespace, illegal characters and chromosome/linkage-group/plasmid keywords.",
-            type = ANNOTATION)
+            type = ANNOTATION,
+            priority = ValidationPriority.CRITICAL)
     public void fix(GFF3Annotation annotation, int line) {
         // No FASTA header source registered for this run -> nothing to fix.
         if (!context.contains(FastaHeaderProvider.class)) {

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFix.java
@@ -84,7 +84,11 @@ public class FastaHeaderNormalisationFix implements Fix {
             ControlledVocabularyUtils.canonicalise(ChromosomeType.class, header.getChromosomeType())
                     .ifPresent(header::setChromosomeType);
         }
-        if (header.getChromosomeLocation() != null) {
+        if ("nuclear".equalsIgnoreCase(header.getChromosomeLocation())) {
+            // "nuclear" is not part of the INSDC /organelle vocabulary -- per the ENA assembly
+            // submission docs, a nuclear chromosome_location is expressed by omitting the field.
+            header.setChromosomeLocation(null);
+        } else if (header.getChromosomeLocation() != null) {
             ControlledVocabularyUtils.canonicalise(ChromosomeLocation.class, header.getChromosomeLocation())
                     .ifPresent(header::setChromosomeLocation);
         }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFix.java
@@ -54,7 +54,8 @@ public class FastaHeaderNormalisationFix implements Fix {
         String accession = annotation.getAccession();
         Optional<FastaHeader> headerOpt = context.get(FastaHeaderProvider.class).getHeader(accession);
         if (headerOpt.isEmpty()) {
-            throw new IllegalStateException("No FASTA header found for accession " + accession);
+            log.warn("No FASTA header found for accession {}", accession);
+            return;
         }
 
         FastaHeader header = headerOpt.get();

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFix.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.validation.fix;
+
+import static uk.ac.ebi.embl.gff3tools.validation.meta.ValidationType.ANNOTATION;
+
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.ControlledVocabularyUtils;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.ControlledVocabularyUtils.ChromosomeLocation;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.ControlledVocabularyUtils.ChromosomeType;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.ControlledVocabularyUtils.MolType;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.ControlledVocabularyUtils.Topology;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
+import uk.ac.ebi.embl.gff3tools.validation.ValidationContext;
+import uk.ac.ebi.embl.gff3tools.validation.meta.Fix;
+import uk.ac.ebi.embl.gff3tools.validation.meta.FixMethod;
+import uk.ac.ebi.embl.gff3tools.validation.meta.Gff3Fix;
+import uk.ac.ebi.embl.gff3tools.validation.meta.InjectContext;
+import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationPriority;
+
+@Slf4j
+@Gff3Fix(
+        name = "FASTA_HEADER_NORMALISATION",
+        description = "Normalises FASTA header values registered for an annotation's accession.")
+public class FastaHeaderNormalisationFix implements Fix {
+
+    @InjectContext
+    private ValidationContext context;
+
+    @FixMethod(
+            rule = "ASCII",
+            description = "Normalises FASTA header values to ASCII.",
+            type = ANNOTATION,
+            priority = ValidationPriority.HIGH)
+    public void AsciiFix(GFF3Annotation annotation, int line) {
+
+        // use Ascii7CharacterConverter from sequencetools if appropriate
+    }
+
+    @FixMethod(
+            rule = "LOWERCASE",
+            description = "Normalises controlled vocabulary fields to their appropriate form.",
+            type = ANNOTATION,
+            priority = ValidationPriority.HIGH)
+    public void ControlledVocabularyNormalisation(GFF3Annotation annotation, int line) {
+        // No FASTA header source registered for this run -> nothing to fix.
+        if (!context.contains(FastaHeaderProvider.class)) {
+            return;
+        }
+
+        String accession = annotation.getAccession();
+        Optional<FastaHeader> headerOpt = context.get(FastaHeaderProvider.class).getHeader(accession);
+        if (headerOpt.isEmpty()) {
+            log.warn("No FASTA header found for accession {}", accession);
+            return;
+        }
+
+        // Each controlled-vocabulary field is normalised to its canonical form when present.
+        // Values that do not match any allowed value are left untouched so that the FASTA header
+        // validation can report them.
+        FastaHeader header = headerOpt.get();
+        if (header.getMoleculeType() != null) {
+            ControlledVocabularyUtils.canonicalise(MolType.class, header.getMoleculeType())
+                    .ifPresent(header::setMoleculeType);
+        }
+        if (header.getTopology() != null) {
+            ControlledVocabularyUtils.canonicalise(Topology.class, header.getTopology())
+                    .ifPresent(header::setTopology);
+        }
+        if (header.getChromosomeType() != null) {
+            ControlledVocabularyUtils.canonicalise(ChromosomeType.class, header.getChromosomeType())
+                    .ifPresent(header::setChromosomeType);
+        }
+        if (header.getChromosomeLocation() != null) {
+            ControlledVocabularyUtils.canonicalise(ChromosomeLocation.class, header.getChromosomeLocation())
+                    .ifPresent(header::setChromosomeLocation);
+        }
+    }
+}

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFix.java
@@ -44,7 +44,7 @@ public class FastaHeaderNormalisationFix implements Fix {
             description =
                     "Folds FASTA header values to ASCII7 and normalises controlled vocabulary fields to their canonical form.",
             type = ANNOTATION,
-            priority = ValidationPriority.HIGH)
+            priority = ValidationPriority.CRITICAL)
     public void normaliseHeaderValues(GFF3Annotation annotation, int line) {
         // No FASTA header source registered for this run -> nothing to fix.
         if (!context.contains(FastaHeaderProvider.class)) {

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFix.java
@@ -14,6 +14,7 @@ import static uk.ac.ebi.embl.gff3tools.validation.meta.ValidationType.ANNOTATION
 
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import uk.ac.ebi.embl.api.validation.helper.Ascii7CharacterConverter;
 import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.ControlledVocabularyUtils;
@@ -39,21 +40,12 @@ public class FastaHeaderNormalisationFix implements Fix {
     private ValidationContext context;
 
     @FixMethod(
-            rule = "ASCII",
-            description = "Normalises FASTA header values to ASCII.",
+            rule = "FASTA_HEADER_VALUE_NORMALISATION",
+            description =
+                    "Folds FASTA header values to ASCII7 and normalises controlled vocabulary fields to their canonical form.",
             type = ANNOTATION,
             priority = ValidationPriority.HIGH)
-    public void AsciiFix(GFF3Annotation annotation, int line) {
-
-        // use Ascii7CharacterConverter from sequencetools if appropriate
-    }
-
-    @FixMethod(
-            rule = "LOWERCASE",
-            description = "Normalises controlled vocabulary fields to their appropriate form.",
-            type = ANNOTATION,
-            priority = ValidationPriority.HIGH)
-    public void ControlledVocabularyNormalisation(GFF3Annotation annotation, int line) {
+    public void normaliseHeaderValues(GFF3Annotation annotation, int line) {
         // No FASTA header source registered for this run -> nothing to fix.
         if (!context.contains(FastaHeaderProvider.class)) {
             return;
@@ -66,10 +58,20 @@ public class FastaHeaderNormalisationFix implements Fix {
             return;
         }
 
-        // Each controlled-vocabulary field is normalised to its canonical form when present.
-        // Values that do not match any allowed value are left untouched so that the FASTA header
-        // validation can report them.
         FastaHeader header = headerOpt.get();
+
+        // First fold every value to ASCII7 (removes diacritics, strips non-printable characters).
+        // Ascii7CharacterConverter.convert is null-safe (null in -> null out) and a no-op for already-clean values.
+        header.setDescription(Ascii7CharacterConverter.convert(header.getDescription()));
+        header.setMoleculeType(Ascii7CharacterConverter.convert(header.getMoleculeType()));
+        header.setTopology(Ascii7CharacterConverter.convert(header.getTopology()));
+        header.setChromosomeType(Ascii7CharacterConverter.convert(header.getChromosomeType()));
+        header.setChromosomeLocation(Ascii7CharacterConverter.convert(header.getChromosomeLocation()));
+        header.setChromosomeName(Ascii7CharacterConverter.convert(header.getChromosomeName()));
+
+        // Normalise controlled-vocabulary fields to their canonical form when present.
+        // Values that do not match any allowed value are left untouched so that the
+        // validation can report them.
         if (header.getMoleculeType() != null) {
             ControlledVocabularyUtils.canonicalise(MolType.class, header.getMoleculeType())
                     .ifPresent(header::setMoleculeType);

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFix.java
@@ -84,11 +84,7 @@ public class FastaHeaderNormalisationFix implements Fix {
             ControlledVocabularyUtils.canonicalise(ChromosomeType.class, header.getChromosomeType())
                     .ifPresent(header::setChromosomeType);
         }
-        if ("nuclear".equalsIgnoreCase(header.getChromosomeLocation())) {
-            // "nuclear" is not part of the INSDC /organelle vocabulary -- per the ENA assembly
-            // submission docs, a nuclear chromosome_location is expressed by omitting the field.
-            header.setChromosomeLocation(null);
-        } else if (header.getChromosomeLocation() != null) {
+        if (header.getChromosomeLocation() != null) {
             ControlledVocabularyUtils.canonicalise(ChromosomeLocation.class, header.getChromosomeLocation())
                     .ifPresent(header::setChromosomeLocation);
         }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFix.java
@@ -54,8 +54,7 @@ public class FastaHeaderNormalisationFix implements Fix {
         String accession = annotation.getAccession();
         Optional<FastaHeader> headerOpt = context.get(FastaHeaderProvider.class).getHeader(accession);
         if (headerOpt.isEmpty()) {
-            log.warn("No FASTA header found for accession {}", accession);
-            return;
+            throw new IllegalStateException("No FASTA header found for accession " + accession);
         }
 
         FastaHeader header = headerOpt.get();

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/FFToGFF3ConverterTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/FFToGFF3ConverterTest.java
@@ -93,7 +93,6 @@ class FFToGFF3ConverterTest {
         if (metadataProvider != null) {
             engineBuilder.withProvider(metadataProvider);
         }
-        engineBuilder.excludeProvider(FastaHeaderProvider.class); // no fasta input here
         ValidationEngine engine = engineBuilder.build();
         FFToGff3Converter converter = new FFToGff3Converter(engine);
         try (BufferedReader testFileReader = Files.newBufferedReader(inputFile);

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/FFToGFF3ConverterTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/FFToGFF3ConverterTest.java
@@ -25,7 +25,6 @@ import uk.ac.ebi.embl.gff3tools.fftogff3.*;
 import uk.ac.ebi.embl.gff3tools.gff3.GFF3File;
 import uk.ac.ebi.embl.gff3tools.metadata.EmblEntryMetadataSource;
 import uk.ac.ebi.embl.gff3tools.metadata.MasterMetadataProvider;
-import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
 import uk.ac.ebi.embl.gff3tools.validation.*;
 
 class FFToGFF3ConverterTest {

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/FFToGFF3ConverterTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/FFToGFF3ConverterTest.java
@@ -25,6 +25,7 @@ import uk.ac.ebi.embl.gff3tools.fftogff3.*;
 import uk.ac.ebi.embl.gff3tools.gff3.GFF3File;
 import uk.ac.ebi.embl.gff3tools.metadata.EmblEntryMetadataSource;
 import uk.ac.ebi.embl.gff3tools.metadata.MasterMetadataProvider;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
 import uk.ac.ebi.embl.gff3tools.validation.*;
 
 class FFToGFF3ConverterTest {
@@ -92,6 +93,7 @@ class FFToGFF3ConverterTest {
         if (metadataProvider != null) {
             engineBuilder.withProvider(metadataProvider);
         }
+        engineBuilder.excludeProvider(FastaHeaderProvider.class); // no fasta input here
         ValidationEngine engine = engineBuilder.build();
         FFToGff3Converter converter = new FFToGff3Converter(engine);
         try (BufferedReader testFileReader = Files.newBufferedReader(inputFile);

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/cli/FileConversionCommandTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/cli/FileConversionCommandTest.java
@@ -177,7 +177,7 @@ class FileConversionCommandTest {
         Path fasta = tempDir.resolve("sequence.fasta");
         Files.writeString(
                 fasta,
-                ">seq1 | {\"description\":\"test\", \"molecule_type\":\"dna\", \"topology\":\"linear\"}\n"
+                ">seq1 | {\"description\":\"test\", \"molecule_type\":\"genomic DNA\", \"topology\":\"linear\"}\n"
                         + "ATGAAATAAGGGCCCAAATTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\n");
 
         Path inputFile = tempDir.resolve("valid.gff3");
@@ -340,7 +340,7 @@ class FileConversionCommandTest {
     }
 
     private static final String GAPPY_FASTA =
-            ">TEST01.1 | {\"description\":\"gappy\", \"molecule_type\":\"dna\", \"topology\":\"linear\"}\n"
+            ">TEST01.1 | {\"description\":\"gappy\", \"molecule_type\":\"genomic DNA\", \"topology\":\"linear\"}\n"
                     + "ATGCATGCNNNNNNNNNNATGCATGCTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\n";
 
     @Test

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/fftogff3/FastaToGff3ConverterTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/fftogff3/FastaToGff3ConverterTest.java
@@ -33,6 +33,18 @@ class FastaToGff3ConverterTest {
 
     private static final Path SINGLE_SEQUENCE = Path.of("src/test/resources/fasta_to_gff3/single_sequence.fasta");
 
+    /**
+     * Builds an engine wired with the input FASTA's headers, mirroring the conversion command
+     * (and {@link #feedsSequenceLookupAndFastaHeaderContextFromInputFasta()}). Without a populated
+     * {@link FastaHeaderProvider}, the header-aware fixes have no header to resolve for the
+     * annotation's accession.
+     */
+    private static ValidationEngine engineWithHeaders(FileSequenceSource source) {
+        FastaHeaderProvider headerProvider = new FastaHeaderProvider();
+        headerProvider.addSource(new FileFastaHeaderSource(source.getSeqIdToHeader()));
+        return new ValidationEngineBuilder().withProvider(headerProvider).build();
+    }
+
     /** Runs the converter and returns the GFF3 output as a string. */
     private static String runConversion(FastaToGff3Converter converter) throws Exception {
         StringWriter output = new StringWriter();
@@ -47,8 +59,8 @@ class FastaToGff3ConverterTest {
     void convertsFastaToGff3WithGapFeatures() throws Exception {
         Path expected = Path.of("src/test/resources/fasta_to_gff3/single_sequence_expected.gff3");
 
-        ValidationEngine engine = new ValidationEngineBuilder().build();
         FileSequenceSource source = new FileSequenceSource(SINGLE_SEQUENCE, SequenceFormat.fasta, null);
+        ValidationEngine engine = engineWithHeaders(source);
         // minGapLength=1 reports every run of N, so both gaps in the fixture are emitted.
         FastaToGff3Converter converter = new FastaToGff3Converter(engine, source, 1);
 
@@ -65,8 +77,8 @@ class FastaToGff3ConverterTest {
 
     @Test
     void emitsGapTypeAndLinkageEvidenceWhenSupplied() throws Exception {
-        ValidationEngine engine = new ValidationEngineBuilder().build();
         FileSequenceSource source = new FileSequenceSource(SINGLE_SEQUENCE, SequenceFormat.fasta, null);
+        ValidationEngine engine = engineWithHeaders(source);
         FastaToGff3Converter converter = new FastaToGff3Converter(engine, source, 1, "within scaffold", "unspecified");
 
         String actual = runConversion(converter);
@@ -79,8 +91,8 @@ class FastaToGff3ConverterTest {
     @Test
     void minGapLengthFiltersShortGaps() throws Exception {
         // Fixture has a 10bp gap (45..54) and a 4bp gap (99..102).
-        ValidationEngine engine = new ValidationEngineBuilder().build();
         FileSequenceSource source = new FileSequenceSource(SINGLE_SEQUENCE, SequenceFormat.fasta, null);
+        ValidationEngine engine = engineWithHeaders(source);
         FastaToGff3Converter converter = new FastaToGff3Converter(engine, source, 10);
 
         String actual = runConversion(converter);
@@ -96,10 +108,12 @@ class FastaToGff3ConverterTest {
     @Test
     void convertsEmptySequenceWithNoGaps() throws Exception {
         Path fasta = Files.createTempFile("empty", ".fasta");
-        Files.writeString(fasta, ">EMPTY | {\"description\":\"No gaps\"}\nATGCATGCATGC\n");
+        Files.writeString(
+                fasta,
+                ">EMPTY | {\"description\":\"No gaps\", \"molecule_type\":\"GENOMIC DNA\", \"topology\":\"linear\"}\nATGCATGCATGC\n");
 
-        ValidationEngine engine = new ValidationEngineBuilder().build();
         FileSequenceSource source = new FileSequenceSource(fasta, SequenceFormat.fasta, null);
+        ValidationEngine engine = engineWithHeaders(source);
         FastaToGff3Converter converter =
                 new FastaToGff3Converter(engine, source, FastaToGff3Converter.DEFAULT_MIN_GAP_LENGTH);
 
@@ -117,10 +131,12 @@ class FastaToGff3ConverterTest {
     void convertsFastaWithSubmissionIdWithoutDot() throws Exception {
         // seqId without a "." should round-trip through the header parser and into the GFF3 seqId.
         Path fasta = Files.createTempFile("no_dot", ".fasta");
-        Files.writeString(fasta, ">TEST01 | {\"description\":\"No dot in id\"}\nATGCATGCNNNNNNNNNNATGCATGC\n");
+        Files.writeString(
+                fasta,
+                ">TEST01 | {\"description\":\"No dot in id\", \"molecule_type\":\"GENOMIC DNA\", \"topology\":\"linear\"}\nATGCATGCNNNNNNNNNNATGCATGC\n");
 
-        ValidationEngine engine = new ValidationEngineBuilder().build();
         FileSequenceSource source = new FileSequenceSource(fasta, SequenceFormat.fasta, null);
+        ValidationEngine engine = engineWithHeaders(source);
         FastaToGff3Converter converter = new FastaToGff3Converter(engine, source, 1);
 
         String actual = runConversion(converter);
@@ -149,11 +165,11 @@ class FastaToGff3ConverterTest {
         Path fasta = Files.createTempFile("multi", ".fasta");
         Files.writeString(
                 fasta,
-                ">SEQ1.1 | {\"description\":\"first\"}\nATGCNNNNNNNNNNATGC\n"
-                        + ">SEQ2.1 | {\"description\":\"second\"}\nGGGGNNNNNNNNNNGGGG\n");
+                ">SEQ1.1 | {\"description\":\"first\", \"molecule_type\":\"GENOMIC DNA\", \"topology\":\"linear\"}\nATGCNNNNNNNNNNATGC\n"
+                        + ">SEQ2.1 | {\"description\":\"second\", \"molecule_type\":\"GENOMIC DNA\", \"topology\":\"linear\"}\nGGGGNNNNNNNNNNGGGG\n");
 
-        ValidationEngine engine = new ValidationEngineBuilder().build();
         FileSequenceSource source = new FileSequenceSource(fasta, SequenceFormat.fasta, null);
+        ValidationEngine engine = engineWithHeaders(source);
         FastaToGff3Converter converter = new FastaToGff3Converter(engine, source, 1);
 
         String actual = runConversion(converter);

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/gff3/GFF3FileReaderTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/gff3/GFF3FileReaderTest.java
@@ -28,7 +28,6 @@ import uk.ac.ebi.embl.gff3tools.fftogff3.GFF3FileFactory;
 import uk.ac.ebi.embl.gff3tools.gff3.directives.GFF3Header;
 import uk.ac.ebi.embl.gff3tools.gff3.directives.GFF3Species;
 import uk.ac.ebi.embl.gff3tools.gff3.reader.GFF3FileReader;
-import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
 import uk.ac.ebi.embl.gff3tools.validation.*;
 import uk.ac.ebi.embl.gff3tools.validation.meta.RuleSeverity;
 
@@ -44,9 +43,7 @@ public class GFF3FileReaderTest {
      * Use this for tests that expect exceptions to be thrown immediately on error.
      */
     ValidationEngine getValidationEngineFailFast() {
-        return getValidationEngineBuilder()
-                .failFast(true)
-                .build();
+        return getValidationEngineBuilder().failFast(true).build();
     }
 
     ValidationEngineBuilder getValidationEngineBuilder() {

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/gff3/GFF3FileReaderTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/gff3/GFF3FileReaderTest.java
@@ -45,7 +45,6 @@ public class GFF3FileReaderTest {
      */
     ValidationEngine getValidationEngineFailFast() {
         return getValidationEngineBuilder()
-                .excludeProvider(FastaHeaderProvider.class)
                 .failFast(true)
                 .build();
     }

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/gff3/GFF3FileReaderTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/gff3/GFF3FileReaderTest.java
@@ -28,6 +28,7 @@ import uk.ac.ebi.embl.gff3tools.fftogff3.GFF3FileFactory;
 import uk.ac.ebi.embl.gff3tools.gff3.directives.GFF3Header;
 import uk.ac.ebi.embl.gff3tools.gff3.directives.GFF3Species;
 import uk.ac.ebi.embl.gff3tools.gff3.reader.GFF3FileReader;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
 import uk.ac.ebi.embl.gff3tools.validation.*;
 import uk.ac.ebi.embl.gff3tools.validation.meta.RuleSeverity;
 
@@ -43,7 +44,10 @@ public class GFF3FileReaderTest {
      * Use this for tests that expect exceptions to be thrown immediately on error.
      */
     ValidationEngine getValidationEngineFailFast() {
-        return getValidationEngineBuilder().failFast(true).build();
+        return getValidationEngineBuilder()
+                .excludeProvider(FastaHeaderProvider.class)
+                .failFast(true)
+                .build();
     }
 
     ValidationEngineBuilder getValidationEngineBuilder() {

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/gff3toff/GFF3MapperTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/gff3toff/GFF3MapperTest.java
@@ -504,7 +504,9 @@ class GFF3MapperTest {
     }
 
     @Test
-    void unrecognisedChromosomeLocationIsPassedThrough() throws Exception {
+    void unrecognisedChromosomeLocationIsSkipped() throws Exception {
+        // Values outside the INSDC /organelle vocabulary must not reach EMBL output --
+        // gff3tools now owns validation of chromosome_location instead of deferring to it.
         MasterMetadata h = createMetadataWithChromosome(null, "Unknown", null);
 
         MasterMetadataProvider provider = providerFromMetadata(Map.of("seq1", h));
@@ -513,9 +515,9 @@ class GFF3MapperTest {
         Entry entry = mapper.mapGFF3ToEntry(createAnnotation("seq1", 1, 1000));
 
         SourceFeature source = (SourceFeature) entry.getFeatures().get(0);
-        List<Qualifier> quals = source.getQualifiers("organelle");
-        assertFalse(quals.isEmpty(), "Expected /organelle qualifier for unrecognised location");
-        assertEquals("unknown", quals.get(0).getValue());
+        assertTrue(
+                source.getQualifiers("organelle").isEmpty(),
+                "Unrecognised chromosome_location should not produce /organelle qualifier");
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/gff3toff/GFF3MapperTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/gff3toff/GFF3MapperTest.java
@@ -491,8 +491,8 @@ class GFF3MapperTest {
     }
 
     @Test
-    void chromosomeLocationNuclearAddsNoQualifier() throws Exception {
-        MasterMetadata h = createMetadataWithChromosome(null, "Nuclear", null);
+    void chromosomeLocationNucleusAddsNoQualifier() throws Exception {
+        MasterMetadata h = createMetadataWithChromosome(null, "Nucleus", null);
 
         MasterMetadataProvider provider = providerFromMetadata(Map.of("seq1", h));
 
@@ -500,7 +500,20 @@ class GFF3MapperTest {
         Entry entry = mapper.mapGFF3ToEntry(createAnnotation("seq1", 1, 1000));
 
         SourceFeature source = (SourceFeature) entry.getFeatures().get(0);
-        assertTrue(source.getQualifiers("organelle").isEmpty(), "Nuclear should not produce /organelle qualifier");
+        assertTrue(source.getQualifiers("organelle").isEmpty(), "Nucleus should not produce /organelle qualifier");
+    }
+
+    @Test
+    void chromosomeLocationCytoplasmAddsNoQualifier() throws Exception {
+        MasterMetadata h = createMetadataWithChromosome(null, "Cytoplasm", null);
+
+        MasterMetadataProvider provider = providerFromMetadata(Map.of("seq1", h));
+
+        GFF3Mapper mapper = new GFF3Mapper(mockReader(), contextWith(provider));
+        Entry entry = mapper.mapGFF3ToEntry(createAnnotation("seq1", 1, 1000));
+
+        SourceFeature source = (SourceFeature) entry.getFeatures().get(0);
+        assertTrue(source.getQualifiers("organelle").isEmpty(), "Cytoplasm should not produce /organelle qualifier");
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/metadata/MasterMetadataTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/metadata/MasterMetadataTest.java
@@ -52,7 +52,7 @@ class MasterMetadataTest {
             assertEquals("This is a test assembly", meta.getComment());
             assertEquals("chr1", meta.getChromosomeName());
             assertEquals("Chromosome", meta.getChromosomeType());
-            assertEquals("Nuclear", meta.getChromosomeLocation());
+            assertEquals("Nucleus", meta.getChromosomeLocation());
             assertNotNull(meta.getFirstPublic());
             assertNotNull(meta.getLastUpdated());
             assertEquals("chromosome", meta.getAssemblyLevel());

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtilsTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtilsTest.java
@@ -128,16 +128,27 @@ class ControlledVocabularyUtilsTest {
     }
 
     @Test
-    void normaliseChromosomeLocationReturnsEnumForNuclear() {
-        // "Nuclear" is an allowed value (a gff3tools extension of the INSDC /organelle list) used to
-        // express the nuclear/cytoplasmic default explicitly, per the team decision.
+    void normaliseChromosomeLocationReturnsEnumForNucleus() {
+        // "Nucleus" and "Cytoplasm" are allowed values (gff3tools extensions of the INSDC /organelle
+        // list) used to express the default location explicitly, per the team decision.
         FastaHeader header = new FastaHeader();
-        header.setChromosomeLocation("Nuclear");
+        header.setChromosomeLocation("Nucleus");
 
         Optional<ControlledVocabularyUtils.ChromosomeLocation> chromosomeLocation =
                 ControlledVocabularyUtils.normaliseChromosomeLocation(header);
 
-        assertEquals(Optional.of(ControlledVocabularyUtils.ChromosomeLocation.NUCLEAR), chromosomeLocation);
+        assertEquals(Optional.of(ControlledVocabularyUtils.ChromosomeLocation.NUCLEUS), chromosomeLocation);
+    }
+
+    @Test
+    void normaliseChromosomeLocationReturnsEnumForCytoplasm() {
+        FastaHeader header = new FastaHeader();
+        header.setChromosomeLocation("Cytoplasm");
+
+        Optional<ControlledVocabularyUtils.ChromosomeLocation> chromosomeLocation =
+                ControlledVocabularyUtils.normaliseChromosomeLocation(header);
+
+        assertEquals(Optional.of(ControlledVocabularyUtils.ChromosomeLocation.CYTOPLASM), chromosomeLocation);
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtilsTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtilsTest.java
@@ -150,4 +150,53 @@ class ControlledVocabularyUtilsTest {
     void chromosomeLocationExposesOriginalControlledVocabularyValue() {
         assertEquals("Chromatophore", ControlledVocabularyUtils.ChromosomeLocation.CHROMATOPHORE.getValue());
     }
+
+    @Test
+    void canonicaliseMatchesIgnoringCase() {
+        assertEquals(
+                Optional.of("genomic DNA"),
+                ControlledVocabularyUtils.canonicalise(ControlledVocabularyUtils.MolType.class, "GENOMIC DNA"));
+        assertEquals(
+                Optional.of("linear"),
+                ControlledVocabularyUtils.canonicalise(ControlledVocabularyUtils.Topology.class, "Linear"));
+        assertEquals(
+                Optional.of("Mitochondrion"),
+                ControlledVocabularyUtils.canonicalise(
+                        ControlledVocabularyUtils.ChromosomeLocation.class, "mitochondrion"));
+    }
+
+    @Test
+    void canonicaliseTrimsEdgeWhitespace() {
+        assertEquals(
+                Optional.of("circular"),
+                ControlledVocabularyUtils.canonicalise(ControlledVocabularyUtils.Topology.class, "  circular\t"));
+    }
+
+    @Test
+    void canonicaliseTransformsDashToUnderscore() {
+        assertEquals(
+                Optional.of("linkage_group"),
+                ControlledVocabularyUtils.canonicalise(
+                        ControlledVocabularyUtils.ChromosomeType.class, "Linkage-Group"));
+    }
+
+    @Test
+    void canonicaliseReturnsEmptyForUnknownValue() {
+        assertTrue(ControlledVocabularyUtils.canonicalise(ControlledVocabularyUtils.Topology.class, "triangle")
+                .isEmpty());
+    }
+
+    @Test
+    void canonicaliseDoesNotTreatSpaceAsUnderscore() {
+        // Only dashes are converted to underscores; "linkage group" stays unmatched.
+        assertTrue(
+                ControlledVocabularyUtils.canonicalise(ControlledVocabularyUtils.ChromosomeType.class, "linkage group")
+                        .isEmpty());
+    }
+
+    @Test
+    void canonicaliseReturnsEmptyForNullValue() {
+        assertTrue(ControlledVocabularyUtils.canonicalise(ControlledVocabularyUtils.MolType.class, null)
+                .isEmpty());
+    }
 }

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtilsTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtilsTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class ControlledVocabularyUtilsTest {
+    @Test
+    void normaliseMolTypeReturnsEnumForControlledVocabularyValue() {
+        FastaHeader header = new FastaHeader();
+        header.setMoleculeType("genomic DNA");
+
+        Optional<ControlledVocabularyUtils.MolType> molType = ControlledVocabularyUtils.normaliseMolType(header);
+
+        assertEquals(Optional.of(ControlledVocabularyUtils.MolType.GENOMIC_DNA), molType);
+    }
+
+    @Test
+    void normaliseMolTypeReturnsEmptyForUnknownValue() {
+        FastaHeader header = new FastaHeader();
+        header.setMoleculeType("DNA");
+
+        Optional<ControlledVocabularyUtils.MolType> molType = ControlledVocabularyUtils.normaliseMolType(header);
+
+        assertTrue(molType.isEmpty());
+    }
+
+    @Test
+    void normaliseMolTypeReturnsEmptyForNullHeader() {
+        Optional<ControlledVocabularyUtils.MolType> molType = ControlledVocabularyUtils.normaliseMolType(null);
+
+        assertTrue(molType.isEmpty());
+    }
+
+    @Test
+    void molTypeExposesOriginalControlledVocabularyValue() {
+        assertEquals("viral cRNA", ControlledVocabularyUtils.MolType.VIRAL_CRNA.getValue());
+    }
+
+    @Test
+    void normaliseTopologyReturnsEnumForControlledVocabularyValue() {
+        FastaHeader header = new FastaHeader();
+        header.setTopology("circular");
+
+        Optional<ControlledVocabularyUtils.Topology> topology = ControlledVocabularyUtils.normaliseTopology(header);
+
+        assertEquals(Optional.of(ControlledVocabularyUtils.Topology.CIRCULAR), topology);
+    }
+
+    @Test
+    void normaliseTopologyReturnsEmptyForUnknownValue() {
+        FastaHeader header = new FastaHeader();
+        header.setTopology("triangle");
+
+        Optional<ControlledVocabularyUtils.Topology> topology = ControlledVocabularyUtils.normaliseTopology(header);
+
+        assertTrue(topology.isEmpty());
+    }
+
+    @Test
+    void normaliseTopologyReturnsEmptyForNullHeader() {
+        Optional<ControlledVocabularyUtils.Topology> topology = ControlledVocabularyUtils.normaliseTopology(null);
+
+        assertTrue(topology.isEmpty());
+    }
+
+    @Test
+    void topologyExposesOriginalControlledVocabularyValue() {
+        assertEquals("linear", ControlledVocabularyUtils.Topology.LINEAR.getValue());
+    }
+
+    @Test
+    void normaliseChromosomeTypeReturnsEnumForControlledVocabularyValue() {
+        FastaHeader header = new FastaHeader();
+        header.setChromosomeType("linkage_group");
+
+        Optional<ControlledVocabularyUtils.ChromosomeType> chromosomeType =
+                ControlledVocabularyUtils.normaliseChromosomeType(header);
+
+        assertEquals(Optional.of(ControlledVocabularyUtils.ChromosomeType.LINKAGE_GROUP), chromosomeType);
+    }
+
+    @Test
+    void normaliseChromosomeTypeReturnsEmptyForUnknownValue() {
+        FastaHeader header = new FastaHeader();
+        header.setChromosomeType("chromosome arm");
+
+        Optional<ControlledVocabularyUtils.ChromosomeType> chromosomeType =
+                ControlledVocabularyUtils.normaliseChromosomeType(header);
+
+        assertTrue(chromosomeType.isEmpty());
+    }
+
+    @Test
+    void normaliseChromosomeTypeReturnsEmptyForNullHeader() {
+        Optional<ControlledVocabularyUtils.ChromosomeType> chromosomeType =
+                ControlledVocabularyUtils.normaliseChromosomeType(null);
+
+        assertTrue(chromosomeType.isEmpty());
+    }
+
+    @Test
+    void chromosomeTypeExposesOriginalControlledVocabularyValue() {
+        assertEquals("multipartite", ControlledVocabularyUtils.ChromosomeType.MULTIPARTITE.getValue());
+    }
+
+    @Test
+    void normaliseChromosomeLocationReturnsEnumForControlledVocabularyValue() {
+        FastaHeader header = new FastaHeader();
+        header.setChromosomeLocation("Mitochondrion");
+
+        Optional<ControlledVocabularyUtils.ChromosomeLocation> chromosomeLocation =
+                ControlledVocabularyUtils.normaliseChromosomeLocation(header);
+
+        assertEquals(Optional.of(ControlledVocabularyUtils.ChromosomeLocation.MITOCHONDRION), chromosomeLocation);
+    }
+
+    @Test
+    void normaliseChromosomeLocationReturnsEmptyForUnknownValue() {
+        FastaHeader header = new FastaHeader();
+        header.setChromosomeLocation("mars");
+
+        Optional<ControlledVocabularyUtils.ChromosomeLocation> chromosomeLocation =
+                ControlledVocabularyUtils.normaliseChromosomeLocation(header);
+
+        assertTrue(chromosomeLocation.isEmpty());
+    }
+
+    @Test
+    void normaliseChromosomeLocationReturnsEmptyForNullHeader() {
+        Optional<ControlledVocabularyUtils.ChromosomeLocation> chromosomeLocation =
+                ControlledVocabularyUtils.normaliseChromosomeLocation(null);
+
+        assertTrue(chromosomeLocation.isEmpty());
+    }
+
+    @Test
+    void chromosomeLocationExposesOriginalControlledVocabularyValue() {
+        assertEquals("Chromatophore", ControlledVocabularyUtils.ChromosomeLocation.CHROMATOPHORE.getValue());
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtilsTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtilsTest.java
@@ -128,17 +128,16 @@ class ControlledVocabularyUtilsTest {
     }
 
     @Test
-    void normaliseChromosomeLocationReturnsEmptyForNuclear() {
-        // "Nuclear" is deliberately not part of the INSDC /organelle vocabulary -- per the ENA
-        // assembly submission docs, a nuclear chromosome is expressed by omitting the field, not by
-        // an explicit value. FastaHeaderNormalisationFix strips a submitted "nuclear" to null.
+    void normaliseChromosomeLocationReturnsEnumForNuclear() {
+        // "Nuclear" is an allowed value (a gff3tools extension of the INSDC /organelle list) used to
+        // express the nuclear/cytoplasmic default explicitly, per the team decision.
         FastaHeader header = new FastaHeader();
         header.setChromosomeLocation("Nuclear");
 
         Optional<ControlledVocabularyUtils.ChromosomeLocation> chromosomeLocation =
                 ControlledVocabularyUtils.normaliseChromosomeLocation(header);
 
-        assertTrue(chromosomeLocation.isEmpty());
+        assertEquals(Optional.of(ControlledVocabularyUtils.ChromosomeLocation.NUCLEAR), chromosomeLocation);
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtilsTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/ControlledVocabularyUtilsTest.java
@@ -128,6 +128,20 @@ class ControlledVocabularyUtilsTest {
     }
 
     @Test
+    void normaliseChromosomeLocationReturnsEmptyForNuclear() {
+        // "Nuclear" is deliberately not part of the INSDC /organelle vocabulary -- per the ENA
+        // assembly submission docs, a nuclear chromosome is expressed by omitting the field, not by
+        // an explicit value. FastaHeaderNormalisationFix strips a submitted "nuclear" to null.
+        FastaHeader header = new FastaHeader();
+        header.setChromosomeLocation("Nuclear");
+
+        Optional<ControlledVocabularyUtils.ChromosomeLocation> chromosomeLocation =
+                ControlledVocabularyUtils.normaliseChromosomeLocation(header);
+
+        assertTrue(chromosomeLocation.isEmpty());
+    }
+
+    @Test
     void normaliseChromosomeLocationReturnsEmptyForUnknownValue() {
         FastaHeader header = new FastaHeader();
         header.setChromosomeLocation("mars");

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/tsvconverter/TSVToGff3ConverterTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/tsvconverter/TSVToGff3ConverterTest.java
@@ -29,6 +29,7 @@ import uk.ac.ebi.embl.gff3tools.exception.ReadException;
 import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
 import uk.ac.ebi.embl.gff3tools.exception.WriteException;
 import uk.ac.ebi.embl.gff3tools.metadata.MasterMetadataProvider;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.JsonHeaderParser;
 import uk.ac.ebi.embl.gff3tools.utils.SourceFeatureDTO;
 import uk.ac.ebi.embl.gff3tools.utils.SourceFeatureUtils;
@@ -224,10 +225,7 @@ public class TSVToGff3ConverterTest {
                 );
         return new ValidationEngineBuilder()
                 .overrideMethodRules(overriddenRules)
-                .disableAutodetectContextProviders()
-                .withProvider(new MasterMetadataProvider())
-                .withProvider(new OntologyClientProvider())
-                .withProvider(new TranslationStateProvider())
+                .excludeProvider(FastaHeaderProvider.class)
                 .failFast(true)
                 .build();
     }

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/tsvconverter/TSVToGff3ConverterTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/tsvconverter/TSVToGff3ConverterTest.java
@@ -222,7 +222,6 @@ public class TSVToGff3ConverterTest {
                 );
         return new ValidationEngineBuilder()
                 .overrideMethodRules(overriddenRules)
-                .excludeProvider(FastaHeaderProvider.class)
                 .failFast(true)
                 .build();
     }

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/tsvconverter/TSVToGff3ConverterTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/tsvconverter/TSVToGff3ConverterTest.java
@@ -28,7 +28,6 @@ import uk.ac.ebi.embl.fastareader.api.SequenceFormatReaderFactory;
 import uk.ac.ebi.embl.gff3tools.exception.ReadException;
 import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
 import uk.ac.ebi.embl.gff3tools.exception.WriteException;
-import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.JsonHeaderParser;
 import uk.ac.ebi.embl.gff3tools.utils.SourceFeatureDTO;
 import uk.ac.ebi.embl.gff3tools.utils.SourceFeatureUtils;

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/tsvconverter/TSVToGff3ConverterTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/tsvconverter/TSVToGff3ConverterTest.java
@@ -28,12 +28,15 @@ import uk.ac.ebi.embl.fastareader.api.SequenceFormatReaderFactory;
 import uk.ac.ebi.embl.gff3tools.exception.ReadException;
 import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
 import uk.ac.ebi.embl.gff3tools.exception.WriteException;
+import uk.ac.ebi.embl.gff3tools.metadata.MasterMetadataProvider;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.JsonHeaderParser;
 import uk.ac.ebi.embl.gff3tools.utils.SourceFeatureDTO;
 import uk.ac.ebi.embl.gff3tools.utils.SourceFeatureUtils;
 import uk.ac.ebi.embl.gff3tools.validation.ValidationEngine;
 import uk.ac.ebi.embl.gff3tools.validation.ValidationEngineBuilder;
 import uk.ac.ebi.embl.gff3tools.validation.meta.RuleSeverity;
+import uk.ac.ebi.embl.gff3tools.validation.provider.OntologyClientProvider;
+import uk.ac.ebi.embl.gff3tools.validation.provider.TranslationStateProvider;
 
 public class TSVToGff3ConverterTest {
 
@@ -221,6 +224,11 @@ public class TSVToGff3ConverterTest {
                 );
         return new ValidationEngineBuilder()
                 .overrideMethodRules(overriddenRules)
+                .disableAutodetectContextProviders()
+                .withProvider(new MasterMetadataProvider())
+                .withProvider(new OntologyClientProvider())
+                .withProvider(new TranslationStateProvider())
+                .failFast(true)
                 .build();
     }
 }

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/tsvconverter/TSVToGff3ConverterTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/tsvconverter/TSVToGff3ConverterTest.java
@@ -28,7 +28,6 @@ import uk.ac.ebi.embl.fastareader.api.SequenceFormatReaderFactory;
 import uk.ac.ebi.embl.gff3tools.exception.ReadException;
 import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
 import uk.ac.ebi.embl.gff3tools.exception.WriteException;
-import uk.ac.ebi.embl.gff3tools.metadata.MasterMetadataProvider;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.JsonHeaderParser;
 import uk.ac.ebi.embl.gff3tools.utils.SourceFeatureDTO;
@@ -36,8 +35,6 @@ import uk.ac.ebi.embl.gff3tools.utils.SourceFeatureUtils;
 import uk.ac.ebi.embl.gff3tools.validation.ValidationEngine;
 import uk.ac.ebi.embl.gff3tools.validation.ValidationEngineBuilder;
 import uk.ac.ebi.embl.gff3tools.validation.meta.RuleSeverity;
-import uk.ac.ebi.embl.gff3tools.validation.provider.OntologyClientProvider;
-import uk.ac.ebi.embl.gff3tools.validation.provider.TranslationStateProvider;
 
 public class TSVToGff3ConverterTest {
 

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/ValidationEngineBuilderTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/ValidationEngineBuilderTest.java
@@ -12,10 +12,12 @@ package uk.ac.ebi.embl.gff3tools.validation;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.gff3tools.TestUtils;
 import uk.ac.ebi.embl.gff3tools.exception.DuplicateValidationRuleException;
 import uk.ac.ebi.embl.gff3tools.gff3.GFF3Feature;
 import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
@@ -41,6 +43,16 @@ class ValidationEngineBuilderTest {
     static class TestFixB implements Fix {
         @FixMethod(rule = "TEST_FIX_B_RULE", type = ValidationType.FEATURE)
         public void fix(GFF3Feature feature, int line) {}
+    }
+
+    @Gff3Fix(name = "RECORDING_FIX", description = "Records whether its fix method ran")
+    static class RecordingFix implements Fix {
+        boolean invoked = false;
+
+        @FixMethod(rule = "RECORDING_FIX_RULE", type = ValidationType.FEATURE)
+        public void fix(GFF3Feature feature, int line) {
+            invoked = true;
+        }
     }
 
     @Gff3Fix(name = "TEST_FIX_A", description = "Duplicate name fix")
@@ -169,6 +181,49 @@ class ValidationEngineBuilderTest {
     }
 
     @Test
+    @DisplayName("build() with overrideClassRules disabling a class keeps it out of the registry")
+    void build_withOverrideClassRules_disablesValidatorClass() {
+        // overrideClassRules is keyed by the class-level @Gff3Validation/@Gff3Fix name.
+        ValidationEngine engine = new ValidationEngineBuilder()
+                .disableAutodetectValidationsAndFixes()
+                .withValidator(new TestValidationA()) // name = "TEST_VALIDATION_A"
+                .overrideClassRules(Map.of("TEST_VALIDATION_A", false))
+                .build();
+
+        ValidationRegistry registry = getRegistry(engine);
+        assertTrue(
+                registry.getValidations().isEmpty(),
+                "Validator class disabled via overrideClassRules should not be registered");
+    }
+
+    @Test
+    @DisplayName("build() with overrideMethodFixs disabling a fix rule skips that fix at runtime")
+    void build_withOverrideMethodFixs_disablesFixExecution() throws Exception {
+        GFF3Feature feature = TestUtils.createGFF3Feature("featureName", "parentName", new HashMap<>());
+
+        // Baseline: without an override the fix runs (FixMethod.enabled defaults to true).
+        RecordingFix enabledFix = new RecordingFix();
+        ValidationEngine enabledEngine = new ValidationEngineBuilder()
+                .disableAutodetectValidationsAndFixes()
+                .disableAutodetectContextProviders()
+                .withFix(enabledFix)
+                .build();
+        enabledEngine.executeFixes(feature, 1);
+        assertTrue(enabledFix.invoked, "Fix should run when its rule is not overridden");
+
+        // overrideMethodFixs is keyed by the FixMethod rule, and a false value skips the fix.
+        RecordingFix disabledFix = new RecordingFix();
+        ValidationEngine disabledEngine = new ValidationEngineBuilder()
+                .disableAutodetectValidationsAndFixes()
+                .disableAutodetectContextProviders()
+                .withFix(disabledFix)
+                .overrideMethodFixs(Map.of("RECORDING_FIX_RULE", false))
+                .build();
+        disabledEngine.executeFixes(feature, 1);
+        assertFalse(disabledFix.invoked, "Fix should be skipped when its rule is overridden to false");
+    }
+
+    @Test
     @DisplayName("build() with explicit fix overriding scanned replaces scanned fix")
     void build_withExplicitFixOverridingScanned_replacesScannedFix() {
         OverrideLocusTagFix overrideInstance = new OverrideLocusTagFix();
@@ -244,6 +299,28 @@ class ValidationEngineBuilderTest {
         ValidationContext ctx = engine.getContext();
         assertEquals("hello", ctx.get(String.class), "String provider should be resolvable");
         assertEquals(42, ctx.get(Integer.class), "Integer provider should be resolvable");
+    }
+
+    @Test
+    @DisplayName("build() with excludeProvider drops the type even when explicitly supplied")
+    void build_withExcludedProvider_keepsTypeOffContext() {
+        StringProvider stringProvider = new StringProvider("hello");
+        IntegerProvider integerProvider = new IntegerProvider(42);
+
+        ValidationEngine engine = new ValidationEngineBuilder()
+                .disableAutodetectContextProviders()
+                .withProvider(stringProvider)
+                .withProvider(integerProvider)
+                .excludeProvider(String.class)
+                .build();
+
+        ValidationContext ctx = engine.getContext();
+        assertEquals(1, ctx.getNumberOfProviders(), "Only the non-excluded provider should remain");
+        assertEquals(42, ctx.get(Integer.class), "Non-excluded provider should be resolvable");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ctx.get(String.class),
+                "Excluded provider should NOT be resolvable even though it was explicitly supplied");
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/ValidationEngineTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/ValidationEngineTest.java
@@ -28,6 +28,7 @@ import uk.ac.ebi.embl.gff3tools.exception.DuplicateValidationRuleException;
 import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
 import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
 import uk.ac.ebi.embl.gff3tools.gff3.GFF3Feature;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
 import uk.ac.ebi.embl.gff3tools.validation.meta.*;
 
 public class ValidationEngineTest {
@@ -66,8 +67,10 @@ public class ValidationEngineTest {
         ValidationEngineBuilder validationEngineBuilder = new ValidationEngineBuilder();
 
         // With fail-fast enabled, validation should throw immediately
-        ValidationEngine validationEngine =
-                validationEngineBuilder.failFast(true).build();
+        ValidationEngine validationEngine = validationEngineBuilder
+                .excludeProvider(FastaHeaderProvider.class)
+                .failFast(true)
+                .build();
 
         GFF3Feature invalidFeature =
                 new GFF3Feature(Optional.empty(), Optional.empty(), "", Optional.empty(), "", "", 0L, 2L, "", "", "");
@@ -75,7 +78,7 @@ public class ValidationEngineTest {
                 Assertions.assertThrows(ValidationException.class, () -> validationEngine.validate(invalidFeature, 1));
 
         Assertions.assertAll(
-                () -> Assertions.assertTrue(ex.getMessage().contains("Violation of rule FASTA_HEADER_MAPPING on line 1")));
+                () -> Assertions.assertTrue(ex.getMessage().contains("Violation of rule LOCATION on line 1")));
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/ValidationEngineTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/ValidationEngineTest.java
@@ -75,7 +75,7 @@ public class ValidationEngineTest {
                 Assertions.assertThrows(ValidationException.class, () -> validationEngine.validate(invalidFeature, 1));
 
         Assertions.assertAll(
-                () -> Assertions.assertTrue(ex.getMessage().contains("Violation of rule LOCATION on line 1")));
+                () -> Assertions.assertTrue(ex.getMessage().contains("Violation of rule FASTA_HEADER_MAPPING on line 1")));
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/ValidationEngineTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/ValidationEngineTest.java
@@ -68,7 +68,6 @@ public class ValidationEngineTest {
 
         // With fail-fast enabled, validation should throw immediately
         ValidationEngine validationEngine = validationEngineBuilder
-                .excludeProvider(FastaHeaderProvider.class)
                 .failFast(true)
                 .build();
 

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/ValidationEngineTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/ValidationEngineTest.java
@@ -28,7 +28,6 @@ import uk.ac.ebi.embl.gff3tools.exception.DuplicateValidationRuleException;
 import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
 import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
 import uk.ac.ebi.embl.gff3tools.gff3.GFF3Feature;
-import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
 import uk.ac.ebi.embl.gff3tools.validation.meta.*;
 
 public class ValidationEngineTest {
@@ -67,9 +66,8 @@ public class ValidationEngineTest {
         ValidationEngineBuilder validationEngineBuilder = new ValidationEngineBuilder();
 
         // With fail-fast enabled, validation should throw immediately
-        ValidationEngine validationEngine = validationEngineBuilder
-                .failFast(true)
-                .build();
+        ValidationEngine validationEngine =
+                validationEngineBuilder.failFast(true).build();
 
         GFF3Feature invalidFeature =
                 new GFF3Feature(Optional.empty(), Optional.empty(), "", Optional.empty(), "", "", 0L, 2L, "", "", "");

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/ChromosomeNameValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/ChromosomeNameValidationTest.java
@@ -45,6 +45,7 @@ class ChromosomeNameValidationTest {
         fastaHeaderProvider = mock(FastaHeaderProvider.class);
         annotation = mock(GFF3Annotation.class);
 
+        when(context.contains(FastaHeaderProvider.class)).thenReturn(true);
         when(context.get(FastaHeaderProvider.class)).thenReturn(fastaHeaderProvider);
 
         injectContext(validation, context);

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/ChromosomeNameValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/ChromosomeNameValidationTest.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.validation.builtin;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
+import uk.ac.ebi.embl.gff3tools.validation.ValidationContext;
+
+class ChromosomeNameValidationTest {
+
+    private static final int LINE = 42;
+
+    private ChromosomeNameValidation validation;
+    private FastaHeaderProvider fastaHeaderProvider;
+    private GFF3Annotation annotation;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        validation = new ChromosomeNameValidation();
+        ValidationContext context = mock(ValidationContext.class);
+        fastaHeaderProvider = mock(FastaHeaderProvider.class);
+        annotation = mock(GFF3Annotation.class);
+
+        when(context.get(FastaHeaderProvider.class)).thenReturn(fastaHeaderProvider);
+
+        injectContext(validation, context);
+    }
+
+    @Nested
+    class ValidateUniqueChromosomeName {
+
+        @Test
+        void doesNothingWhenNoFastaHeaderExistsForAccession() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1")).thenReturn(Optional.empty());
+
+            assertDoesNotThrow(() -> validation.validateChromosomeNameUnique(annotation, LINE));
+        }
+
+        @Test
+        void doesNothingWhenChromosomeNameIsMissing() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1")).thenReturn(Optional.of(headerWithChromosomeName(null)));
+
+            assertDoesNotThrow(() -> validation.validateChromosomeNameUnique(annotation, LINE));
+
+            when(annotation.getAccession()).thenReturn("CM000002.1");
+            when(fastaHeaderProvider.getHeader("CM000002.1")).thenReturn(Optional.of(headerWithChromosomeName("  ")));
+
+            assertDoesNotThrow(() -> validation.validateChromosomeNameUnique(annotation, LINE));
+        }
+
+        @Test
+        void doesNothingWhenChromosomeNamesAreUnique() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1")).thenReturn(Optional.of(headerWithChromosomeName("I")));
+
+            assertDoesNotThrow(() -> validation.validateChromosomeNameUnique(annotation, LINE));
+
+            when(annotation.getAccession()).thenReturn("CM000002.1");
+            when(fastaHeaderProvider.getHeader("CM000002.1")).thenReturn(Optional.of(headerWithChromosomeName("II")));
+
+            assertDoesNotThrow(() -> validation.validateChromosomeNameUnique(annotation, LINE));
+        }
+
+        @Test
+        void doesNothingWhenSameAccessionIsValidatedAgain() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1")).thenReturn(Optional.of(headerWithChromosomeName("I")));
+
+            assertDoesNotThrow(() -> validation.validateChromosomeNameUnique(annotation, LINE));
+            assertDoesNotThrow(() -> validation.validateChromosomeNameUnique(annotation, LINE));
+        }
+
+        @Test
+        void throwsValidationExceptionWhenChromosomeNameIsDuplicated() throws ValidationException {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1")).thenReturn(Optional.of(headerWithChromosomeName("I")));
+            validation.validateChromosomeNameUnique(annotation, LINE);
+
+            when(annotation.getAccession()).thenReturn("CM000002.1");
+            when(fastaHeaderProvider.getHeader("CM000002.1")).thenReturn(Optional.of(headerWithChromosomeName(" I ")));
+
+            ValidationException exception = assertThrows(
+                    ValidationException.class, () -> validation.validateChromosomeNameUnique(annotation, LINE));
+
+            String message = exception.getMessage();
+            assertTrue(message.contains(ChromosomeNameValidation.CHROMOSOME_NAME_UNIQUE_RULE));
+            assertTrue(message.contains("Duplicate chromosome_name 'I'"));
+            assertTrue(message.contains("CM000001.1"));
+            assertTrue(message.contains("CM000002.1"));
+        }
+    }
+
+    @Nested
+    class ValidateChromosomeOrLinkageGroupNameAssigned {
+
+        @Test
+        void doesNothingWhenNoFastaHeaderExistsForAccession() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1")).thenReturn(Optional.empty());
+
+            assertDoesNotThrow(() -> validation.validateChromosomeOrLinkageGroupNameAssigned(annotation, LINE));
+        }
+
+        @Test
+        void doesNothingWhenChromosomeTypeIsMissingOrNotRestricted() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName(null, "unknown")));
+
+            assertDoesNotThrow(() -> validation.validateChromosomeOrLinkageGroupNameAssigned(annotation, LINE));
+
+            when(annotation.getAccession()).thenReturn("CM000002.1");
+            when(fastaHeaderProvider.getHeader("CM000002.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName("plasmid", "unknown")));
+
+            assertDoesNotThrow(() -> validation.validateChromosomeOrLinkageGroupNameAssigned(annotation, LINE));
+        }
+
+        @Test
+        void doesNothingWhenRestrictedChromosomeTypeHasAssignedName() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName("chromosome", "I")));
+
+            assertDoesNotThrow(() -> validation.validateChromosomeOrLinkageGroupNameAssigned(annotation, LINE));
+
+            when(annotation.getAccession()).thenReturn("CM000002.1");
+            when(fastaHeaderProvider.getHeader("CM000002.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName("linkage_group", "LG1")));
+
+            assertDoesNotThrow(() -> validation.validateChromosomeOrLinkageGroupNameAssigned(annotation, LINE));
+        }
+
+        @Test
+        void throwsValidationExceptionWhenChromosomeNameIsUnknownForChromosome() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName("chromosome", "Unknown")));
+
+            ValidationException exception = assertThrows(
+                    ValidationException.class,
+                    () -> validation.validateChromosomeOrLinkageGroupNameAssigned(annotation, LINE));
+
+            String message = exception.getMessage();
+            assertTrue(message.contains(ChromosomeNameValidation.CHROMOSOME_OR_LINKAGE_GROUP_NAME_NOT_UNASSIGNED_RULE));
+            assertTrue(message.contains("chromosome_name 'Unknown' is not permitted"));
+            assertTrue(message.contains("chromosome_type 'chromosome'"));
+        }
+
+        @Test
+        void throwsValidationExceptionWhenChromosomeNameContainsUnassignedWordForLinkageGroup() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName("linkage_group", "LG Unk")));
+
+            ValidationException exception = assertThrows(
+                    ValidationException.class,
+                    () -> validation.validateChromosomeOrLinkageGroupNameAssigned(annotation, LINE));
+
+            String message = exception.getMessage();
+            assertTrue(message.contains(ChromosomeNameValidation.CHROMOSOME_OR_LINKAGE_GROUP_NAME_NOT_UNASSIGNED_RULE));
+            assertTrue(message.contains("chromosome_name 'LG Unk' is not permitted"));
+            assertTrue(message.contains("chromosome_type 'linkage_group'"));
+        }
+
+        @Test
+        void throwsValidationExceptionWhenChromosomeNameIsZeroForRestrictedChromosomeType() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName("chromosome", "0")));
+
+            ValidationException exception = assertThrows(
+                    ValidationException.class,
+                    () -> validation.validateChromosomeOrLinkageGroupNameAssigned(annotation, LINE));
+
+            String message = exception.getMessage();
+            assertTrue(message.contains(ChromosomeNameValidation.CHROMOSOME_OR_LINKAGE_GROUP_NAME_NOT_UNASSIGNED_RULE));
+            assertTrue(message.contains("chromosome_name '0' is not permitted"));
+        }
+    }
+
+    @Nested
+    class ValidatePlasmidChromosomeNameFormat {
+
+        @Test
+        void doesNothingWhenNoFastaHeaderExistsForAccession() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1")).thenReturn(Optional.empty());
+
+            assertDoesNotThrow(() -> validation.validatePlasmidChromosomeNameFormat(annotation, LINE));
+        }
+
+        @Test
+        void doesNothingWhenChromosomeTypeIsMissingOrNotPlasmid() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName(null, "Plasmid1")));
+
+            assertDoesNotThrow(() -> validation.validatePlasmidChromosomeNameFormat(annotation, LINE));
+
+            when(annotation.getAccession()).thenReturn("CM000002.1");
+            when(fastaHeaderProvider.getHeader("CM000002.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName("chromosome", "Plasmid1")));
+
+            assertDoesNotThrow(() -> validation.validatePlasmidChromosomeNameFormat(annotation, LINE));
+        }
+
+        @Test
+        void doesNothingWhenPlasmidNameStartsWithLowercaseP() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName("plasmid", "pABC1")));
+
+            assertDoesNotThrow(() -> validation.validatePlasmidChromosomeNameFormat(annotation, LINE));
+        }
+
+        @Test
+        void doesNothingWhenPlasmidNameIsMegaplasmidName() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName("plasmid", "pMegaplasmid1")));
+
+            assertDoesNotThrow(() -> validation.validatePlasmidChromosomeNameFormat(annotation, LINE));
+        }
+
+        @Test
+        void doesNothingWhenPlasmidNameIsAllowedUnnamedName() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName("plasmid", "unnamed")));
+
+            assertDoesNotThrow(() -> validation.validatePlasmidChromosomeNameFormat(annotation, LINE));
+
+            when(annotation.getAccession()).thenReturn("CM000002.1");
+            when(fastaHeaderProvider.getHeader("CM000002.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName("plasmid", "unnamed2")));
+
+            assertDoesNotThrow(() -> validation.validatePlasmidChromosomeNameFormat(annotation, LINE));
+        }
+
+        @Test
+        void doesNothingWhenPlasmidNameIsAllowedHistoricalName() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName("plasmid", "F1")));
+
+            assertDoesNotThrow(() -> validation.validatePlasmidChromosomeNameFormat(annotation, LINE));
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+                strings = {
+                    "F", // F factor without digits
+                    "R1",
+                    "R100",
+                    "R1822", // R factors
+                    "RP1",
+                    "RP4",
+                    "RK2",
+                    "R68", // RP / RK factors
+                    "ColE1",
+                    "ColIb",
+                    "ColIb-P9",
+                    "ColV", // Col factors
+                    "Ti",
+                    "Ri", // Ti / Ri plasmids
+                    "Megaplasmid" // megaplasmid
+                })
+        void doesNothingWhenPlasmidNameIsAdditionalHistoricalName(String chromosomeName) {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName("plasmid", chromosomeName)));
+
+            assertDoesNotThrow(() -> validation.validatePlasmidChromosomeNameFormat(annotation, LINE));
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+                strings = {
+                    "R", // R factor needs digits
+                    "Col", // Col factor needs a suffix
+                    "FX", // F factor only allows digits
+                    "Tx" // not a Ti / Ri plasmid
+                })
+        void throwsValidationExceptionWhenPlasmidNameResemblesButIsNotHistoricalName(String chromosomeName) {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName("plasmid", chromosomeName)));
+
+            assertThrows(
+                    ValidationException.class, () -> validation.validatePlasmidChromosomeNameFormat(annotation, LINE));
+        }
+
+        @Test
+        void throwsValidationExceptionWhenPlasmidNameDoesNotStartWithLowercaseP() {
+            when(annotation.getAccession()).thenReturn("CM000001.1");
+            when(fastaHeaderProvider.getHeader("CM000001.1"))
+                    .thenReturn(Optional.of(headerWithChromosomeTypeAndName("plasmid", "P34")));
+
+            ValidationException exception = assertThrows(
+                    ValidationException.class, () -> validation.validatePlasmidChromosomeNameFormat(annotation, LINE));
+
+            String message = exception.getMessage();
+            assertTrue(message.contains(ChromosomeNameValidation.PLASMID_CHROMOSOME_NAME_FORMAT_RULE));
+            assertTrue(message.contains("chromosome_name 'P34' is not a permitted plasmid name"));
+        }
+    }
+
+    private static FastaHeader headerWithChromosomeName(String chromosomeName) {
+        FastaHeader header = new FastaHeader();
+        header.setChromosomeName(chromosomeName);
+        return header;
+    }
+
+    private static FastaHeader headerWithChromosomeTypeAndName(String chromosomeType, String chromosomeName) {
+        FastaHeader header = headerWithChromosomeName(chromosomeName);
+        header.setChromosomeType(chromosomeType);
+        return header;
+    }
+
+    private static void injectContext(ChromosomeNameValidation validation, ValidationContext context) throws Exception {
+        Field field = ChromosomeNameValidation.class.getDeclaredField("context");
+        field.setAccessible(true);
+        field.set(validation, context);
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/ChromosomeNameValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/ChromosomeNameValidationTest.java
@@ -35,13 +35,14 @@ class ChromosomeNameValidationTest {
     private static final int LINE = 42;
 
     private ChromosomeNameValidation validation;
+    private ValidationContext context;
     private FastaHeaderProvider fastaHeaderProvider;
     private GFF3Annotation annotation;
 
     @BeforeEach
     void setUp() throws Exception {
         validation = new ChromosomeNameValidation();
-        ValidationContext context = mock(ValidationContext.class);
+        context = mock(ValidationContext.class);
         fastaHeaderProvider = mock(FastaHeaderProvider.class);
         annotation = mock(GFF3Annotation.class);
 
@@ -49,6 +50,32 @@ class ChromosomeNameValidationTest {
         when(context.get(FastaHeaderProvider.class)).thenReturn(fastaHeaderProvider);
 
         injectContext(validation, context);
+    }
+
+    @Nested
+    class NoFastaHeaderProvider {
+
+        // When no FastaHeaderProvider is registered (e.g. a header-less conversion), there is no
+        // chromosome_name to resolve, so none of the validation methods should throw.
+        @BeforeEach
+        void noProvider() {
+            when(context.contains(FastaHeaderProvider.class)).thenReturn(false);
+        }
+
+        @Test
+        void validateChromosomeNameUniqueDoesNotThrow() {
+            assertDoesNotThrow(() -> validation.validateChromosomeNameUnique(annotation, LINE));
+        }
+
+        @Test
+        void validateChromosomeOrLinkageGroupNameAssignedDoesNotThrow() {
+            assertDoesNotThrow(() -> validation.validateChromosomeOrLinkageGroupNameAssigned(annotation, LINE));
+        }
+
+        @Test
+        void validatePlasmidChromosomeNameFormatDoesNotThrow() {
+            assertDoesNotThrow(() -> validation.validatePlasmidChromosomeNameFormat(annotation, LINE));
+        }
     }
 
     @Nested

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidationTest.java
@@ -241,6 +241,34 @@ public class FastaHeaderFormatValidationTest {
         }
 
         @Test
+        void shouldPassValidation_whenNuclearChromosomeOmitsLocation() {
+            // Per the ENA assembly submission docs, a nuclear chromosome is expressed by omitting
+            // chromosome_location entirely -- name + type alone is a valid combination.
+            FastaHeader h = validHeader();
+            h.setChromosomeName("1");
+            h.setChromosomeType("chromosome");
+
+            List<String> errors = FastaHeaderFormatValidation.validate(h);
+
+            assertTrue(errors.isEmpty());
+        }
+
+        @Test
+        void shouldFail_whenChromosomeLocationIsLiteralNuclear() {
+            // "nuclear" is not part of the INSDC /organelle vocabulary, so validate() alone rejects
+            // it as an invalid value; FastaHeaderNormalisationFix strips it to null upstream of
+            // validation in the real pipeline (see FastaHeaderNormalisationFixTest).
+            FastaHeader h = validHeader();
+            h.setChromosomeName("1");
+            h.setChromosomeType("chromosome");
+            h.setChromosomeLocation("Nuclear");
+
+            List<String> errors = FastaHeaderFormatValidation.validate(h);
+
+            assertTrue(errors.contains("invalid chromosome_location - see allowed values list"));
+        }
+
+        @Test
         void shouldFail_whenInvalidChromosomeLocation() {
             FastaHeader h = validHeader();
             // all three chromosome fields present -> valid combination, so only the location is at fault
@@ -301,10 +329,12 @@ public class FastaHeaderFormatValidationTest {
     }
 
     /**
-     * Covers the allowed combinations of the optional chromosome fields. Only three combinations are
-     * valid: none present (unplaced contig), chromosome_name only (unlocalized), or all three present
-     * (chromosome). Every other combination must be reported. Field values below are all individually
-     * valid so the combination rule is the only thing under test.
+     * Covers the allowed combinations of the optional chromosome fields, mirroring the ENA Chromosome
+     * List File column structure: none present (unplaced contig), chromosome_name only (unlocalized),
+     * or chromosome_name + chromosome_type with chromosome_location optional on top (chromosome; a
+     * nuclear/cytoplasmic chromosome omits chromosome_location). Every other combination must be
+     * reported. Field values below are all individually valid so the combination rule is the only
+     * thing under test.
      */
     @Nested
     public class ChromosomeFieldCombinationTest {
@@ -328,8 +358,13 @@ public class FastaHeaderFormatValidationTest {
         }
 
         @Test
-        void shouldPass_whenAllThreeChromosomeFieldsPresent() { // table row 4: chromosome
+        void shouldPass_whenAllThreeChromosomeFieldsPresent() { // table row 4: chromosome, explicit location
             assertFalse(combinationErrors(NAME, TYPE, LOCATION).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
+        }
+
+        @Test
+        void shouldPass_whenChromosomeNameAndTypePresentWithoutLocation() { // table row 4: chromosome, nuclear default
+            assertFalse(combinationErrors(NAME, TYPE, null).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
         }
 
         // --- invalid combinations ---
@@ -352,11 +387,6 @@ public class FastaHeaderFormatValidationTest {
         @Test
         void shouldFail_whenChromosomeNameAndLocationPresentWithoutType() { // table row 3.b
             assertTrue(combinationErrors(NAME, null, LOCATION).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
-        }
-
-        @Test
-        void shouldFail_whenChromosomeNameAndTypePresentWithoutLocation() { // table row 3.c
-            assertTrue(combinationErrors(NAME, TYPE, null).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
         }
 
         private List<String> combinationErrors(String name, String type, String location) {

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidationTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.validation.builtin;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
+import uk.ac.ebi.embl.gff3tools.validation.ValidationContext;
+
+public class FastaHeaderFormatValidationTest {
+
+    private static final int LINE = 42;
+    private static final String ACCESSION = "CM000001.1";
+    private static final List<String> VALID_MOL_TYPES = List.of(
+            "genomic DNA",
+            "genomic RNA",
+            "mRNA",
+            "tRNA",
+            "rRNA",
+            "other RNA",
+            "other DNA",
+            "transcribed RNA",
+            "viral cRNA",
+            "unassigned DNA",
+            "unassigned RNA");
+
+    private FastaHeaderFormatValidation validation;
+    private ValidationContext context;
+    private FastaHeaderProvider fastaHeaderProvider;
+    private GFF3Annotation annotation;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        validation = new FastaHeaderFormatValidation();
+
+        context = mock(ValidationContext.class);
+        fastaHeaderProvider = mock(FastaHeaderProvider.class);
+        annotation = mock(GFF3Annotation.class);
+
+        when(context.get(FastaHeaderProvider.class)).thenReturn(fastaHeaderProvider);
+        when(annotation.getAccession()).thenReturn(ACCESSION);
+
+        injectContext(validation, context);
+    }
+
+    @Test
+    void validateDoesNothingWhenNoFastaHeaderExistsForAccession() {
+        when(fastaHeaderProvider.getHeader(ACCESSION)).thenReturn(Optional.empty());
+
+        assertDoesNotThrow(() -> validation.validate(annotation, LINE));
+    }
+
+    @Test
+    void validateDoesNothingWhenFastaHeaderIsValid() {
+        FastaHeader header = validHeader();
+
+        when(fastaHeaderProvider.getHeader(ACCESSION)).thenReturn(Optional.of(header));
+
+        assertDoesNotThrow(() -> validation.validate(annotation, LINE));
+    }
+
+    @Test
+    void validateThrowsValidationExceptionWhenFastaHeaderIsInvalid() {
+        FastaHeader header = mock(FastaHeader.class);
+
+        when(header.getDescription()).thenReturn("");
+        when(header.getMoleculeType()).thenReturn("genomic DNA");
+        when(header.getTopology()).thenReturn("linear");
+
+        when(fastaHeaderProvider.getHeader(ACCESSION)).thenReturn(Optional.of(header));
+
+        ValidationException exception =
+                assertThrows(ValidationException.class, () -> validation.validate(annotation, LINE));
+
+        String message = exception.getMessage();
+
+        assertTrue(message.contains("FASTA_HEADER_SYNTAX_VALIDATION"));
+        assertTrue(message.contains("Fasta header with id " + ACCESSION));
+        assertTrue(message.contains("description is mandatory"));
+    }
+
+    @Test
+    void validateIncludesAllSyntaxViolationsInThrownException() {
+        FastaHeader header = mock(FastaHeader.class);
+
+        when(header.getDescription()).thenReturn("");
+        when(header.getMoleculeType()).thenReturn("");
+        when(header.getTopology()).thenReturn("invalid-topology");
+
+        when(fastaHeaderProvider.getHeader(ACCESSION)).thenReturn(Optional.of(header));
+
+        ValidationException exception =
+                assertThrows(ValidationException.class, () -> validation.validate(annotation, LINE));
+
+        String message = exception.getMessage();
+
+        assertTrue(message.contains("Fasta header with id " + ACCESSION));
+        assertTrue(message.contains("description is mandatory"));
+        assertTrue(message.contains("molecule_type is mandatory"));
+        assertTrue(message.contains("topology must be 'linear' or 'circular'"));
+    }
+
+    @Test
+    void validateUsesAnnotationAccessionToResolveHeader() {
+        String differentAccession = "CM999999.1";
+        FastaHeader validHeader = validHeader();
+        FastaHeader invalidHeader = mock(FastaHeader.class);
+        when(annotation.getAccession()).thenReturn(ACCESSION);
+        when(fastaHeaderProvider.getHeader(ACCESSION)).thenReturn(Optional.of(validHeader));
+        when(fastaHeaderProvider.getHeader(differentAccession)).thenReturn(Optional.of(invalidHeader));
+
+        when(invalidHeader.getDescription()).thenReturn("");
+        when(invalidHeader.getMoleculeType()).thenReturn("");
+        when(invalidHeader.getTopology()).thenReturn("");
+
+        assertDoesNotThrow(() -> validation.validate(annotation, LINE));
+    }
+
+    @Nested
+    public class ValidateTest {
+        @Test
+        void shouldPassValidation_whenValidHeader() {
+            FastaHeader h = new FastaHeader();
+            h.setDescription("Some description");
+            h.setMoleculeType("genomic DNA");
+            h.setTopology("linear");
+            h.setChromosomeType("chromosome");
+            h.setChromosomeLocation("Mitochondrion");
+            h.setChromosomeName("seq1_valid");
+
+            FastaHeader h2 = new FastaHeader();
+            h2.setDescription("Some description");
+            h2.setMoleculeType("genomic DNA");
+            h2.setTopology("circular");
+
+            List<String> errors = FastaHeaderFormatValidation.validate(h);
+            List<String> errors2 = FastaHeaderFormatValidation.validate(h2);
+
+            assertTrue(errors.isEmpty());
+            assertTrue(errors2.isEmpty());
+        }
+
+        @Test
+        void shouldFailValidation_whenHeaderNullOrEmpty() {
+            FastaHeader h = new FastaHeader();
+
+            List<String> errors = FastaHeaderFormatValidation.validate(h);
+            List<String> errors2 = FastaHeaderFormatValidation.validate(null);
+
+            assertFalse(errors.isEmpty());
+            assertFalse(errors2.isEmpty());
+        }
+
+        @Test
+        void shouldFail_whenMandatoryFieldsMissing() {
+            FastaHeader h = new FastaHeader();
+
+            List<String> errors = FastaHeaderFormatValidation.validate(h);
+
+            assertTrue(errors.contains("description is mandatory"));
+            assertTrue(errors.contains("molecule_type is mandatory"));
+            assertTrue(errors.contains("topology is mandatory"));
+        }
+
+        @Test
+        void shouldFail_whenInvalidTopology() {
+            FastaHeader h = validHeader();
+            h.setTopology("triangle");
+
+            List<String> errors = FastaHeaderFormatValidation.validate(h);
+
+            assertTrue(errors.contains("topology must be 'linear' or 'circular'"));
+        }
+
+        @Test
+        void shouldPassValidation_whenMoleculeTypeIsAllowedMolTypeValue() {
+            for (String molType : VALID_MOL_TYPES) {
+                FastaHeader h = validHeader();
+                h.setMoleculeType(molType);
+
+                List<String> errors = FastaHeaderFormatValidation.validate(h);
+
+                assertTrue(errors.isEmpty(), "Expected mol_type value to be valid: " + molType);
+            }
+        }
+
+        @Test
+        void shouldFail_whenInvalidMoleculeType() {
+            FastaHeader h = validHeader();
+            h.setMoleculeType("DNA");
+
+            List<String> errors = FastaHeaderFormatValidation.validate(h);
+
+            assertTrue(errors.contains("molecule_type must be one of the allowed mol_type qualifier values"));
+        }
+
+        @Test
+        void shouldFail_whenInvalidChromosomeType() {
+            FastaHeader h = validHeader();
+            h.setChromosomeType("invalid_type");
+
+            List<String> errors = FastaHeaderFormatValidation.validate(h);
+
+            assertTrue(errors.contains("invalid chromosome_type - see allowed values list"));
+        }
+
+        @Test
+        void shouldFail_whenInvalidChromosomeLocation() {
+            FastaHeader h = validHeader();
+            h.setChromosomeLocation("mars");
+
+            List<String> errors = FastaHeaderFormatValidation.validate(h);
+
+            assertTrue(errors.contains("invalid chromosome_location - see allowed values list"));
+        }
+
+        @Test
+        void shouldFail_whenInvalidChromosomeNamePattern() {
+            FastaHeader h = validHeader();
+            h.setChromosomeName("-badName");
+
+            List<String> errors = FastaHeaderFormatValidation.validate(h);
+
+            assertTrue(errors.contains("invalid chromosome_name format"));
+        }
+
+        @Test
+        void shouldFail_whenChromosomeNameTooLong() {
+            FastaHeader h = validHeader();
+            h.setChromosomeName("a".repeat(33));
+
+            List<String> errors = FastaHeaderFormatValidation.validate(h);
+
+            assertTrue(errors.contains("chromosome_name must be shorter than 33 characters"));
+        }
+
+        @Test
+        void shouldFail_whenChromosomeNameContainsForbiddenWord() {
+            FastaHeader h = validHeader();
+            h.setChromosomeName("myChromosome1");
+
+            List<String> errors = FastaHeaderFormatValidation.validate(h);
+
+            assertTrue(errors.stream().anyMatch(e -> e.contains("forbidden term")));
+        }
+
+        @Test
+        void shouldFail_whenHeaderIsNull() {
+            List<String> errors = FastaHeaderFormatValidation.validate(null);
+
+            assertEquals(1, errors.size());
+            assertEquals("FastaHeader must not be null", errors.get(0));
+        }
+
+        private FastaHeader validHeader() {
+            FastaHeader h = new FastaHeader();
+            h.setDescription("desc");
+            h.setMoleculeType("genomic DNA");
+            h.setTopology("linear");
+            return h;
+        }
+    }
+
+    // --------------------------- helpers --------------------------------
+    private static FastaHeader validHeader() {
+        FastaHeader header = mock(FastaHeader.class);
+
+        when(header.getDescription()).thenReturn("Complete genome");
+        when(header.getMoleculeType()).thenReturn("genomic DNA");
+        when(header.getTopology()).thenReturn("linear");
+        when(header.getChromosomeType()).thenReturn(null);
+        when(header.getChromosomeLocation()).thenReturn(null);
+        when(header.getChromosomeName()).thenReturn(null);
+
+        return header;
+    }
+
+    private static void injectContext(FastaHeaderFormatValidation validation, ValidationContext context)
+            throws Exception {
+        Field field = FastaHeaderFormatValidation.class.getDeclaredField("context");
+        field.setAccessible(true);
+        field.set(validation, context);
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidationTest.java
@@ -230,6 +230,9 @@ public class FastaHeaderFormatValidationTest {
         @Test
         void shouldFail_whenInvalidChromosomeType() {
             FastaHeader h = validHeader();
+            // all three chromosome fields present -> valid combination, so only the type value is at fault
+            h.setChromosomeName("seq1_valid");
+            h.setChromosomeLocation("Mitochondrion");
             h.setChromosomeType("invalid_type");
 
             List<String> errors = FastaHeaderFormatValidation.validate(h);
@@ -240,6 +243,9 @@ public class FastaHeaderFormatValidationTest {
         @Test
         void shouldFail_whenInvalidChromosomeLocation() {
             FastaHeader h = validHeader();
+            // all three chromosome fields present -> valid combination, so only the location is at fault
+            h.setChromosomeName("seq1_valid");
+            h.setChromosomeType("chromosome");
             h.setChromosomeLocation("mars");
 
             List<String> errors = FastaHeaderFormatValidation.validate(h);
@@ -291,6 +297,77 @@ public class FastaHeaderFormatValidationTest {
             h.setMoleculeType("genomic DNA");
             h.setTopology("linear");
             return h;
+        }
+    }
+
+    /**
+     * Covers the allowed combinations of the optional chromosome fields. Only three combinations are
+     * valid: none present (unplaced contig), chromosome_name only (unlocalized), or all three present
+     * (chromosome). Every other combination must be reported. Field values below are all individually
+     * valid so the combination rule is the only thing under test.
+     */
+    @Nested
+    public class ChromosomeFieldCombinationTest {
+
+        private static final String COMBINATION_ERROR = "invalid combination of optional chromosome fields";
+
+        private static final String NAME = "seq1_valid";
+        private static final String TYPE = "chromosome";
+        private static final String LOCATION = "Mitochondrion";
+
+        // --- valid combinations ---
+
+        @Test
+        void shouldPass_whenNoChromosomeFieldsPresent() { // table row 1: contig (unplaced)
+            assertFalse(combinationErrors(null, null, null).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
+        }
+
+        @Test
+        void shouldPass_whenOnlyChromosomeNamePresent() { // table row 2.a: unlocalized
+            assertFalse(combinationErrors(NAME, null, null).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
+        }
+
+        @Test
+        void shouldPass_whenAllThreeChromosomeFieldsPresent() { // table row 4: chromosome
+            assertFalse(combinationErrors(NAME, TYPE, LOCATION).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
+        }
+
+        // --- invalid combinations ---
+
+        @Test
+        void shouldFail_whenOnlyChromosomeTypePresent() { // table row 2.b
+            assertTrue(combinationErrors(null, TYPE, null).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
+        }
+
+        @Test
+        void shouldFail_whenOnlyChromosomeLocationPresent() { // table row 2.c
+            assertTrue(combinationErrors(null, null, LOCATION).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
+        }
+
+        @Test
+        void shouldFail_whenChromosomeTypeAndLocationPresentWithoutName() { // table row 3.a
+            assertTrue(combinationErrors(null, TYPE, LOCATION).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
+        }
+
+        @Test
+        void shouldFail_whenChromosomeNameAndLocationPresentWithoutType() { // table row 3.b
+            assertTrue(combinationErrors(NAME, null, LOCATION).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
+        }
+
+        @Test
+        void shouldFail_whenChromosomeNameAndTypePresentWithoutLocation() { // table row 3.c
+            assertTrue(combinationErrors(NAME, TYPE, null).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
+        }
+
+        private List<String> combinationErrors(String name, String type, String location) {
+            FastaHeader h = new FastaHeader();
+            h.setDescription("desc");
+            h.setMoleculeType("genomic DNA");
+            h.setTopology("linear");
+            h.setChromosomeName(name);
+            h.setChromosomeType(type);
+            h.setChromosomeLocation(location);
+            return FastaHeaderFormatValidation.validate(h);
         }
     }
 

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidationTest.java
@@ -61,6 +61,7 @@ public class FastaHeaderFormatValidationTest {
         fastaHeaderProvider = mock(FastaHeaderProvider.class);
         annotation = mock(GFF3Annotation.class);
 
+        when(context.contains(FastaHeaderProvider.class)).thenReturn(true);
         when(context.get(FastaHeaderProvider.class)).thenReturn(fastaHeaderProvider);
         when(annotation.getAccession()).thenReturn(ACCESSION);
 

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidationTest.java
@@ -241,23 +241,9 @@ public class FastaHeaderFormatValidationTest {
         }
 
         @Test
-        void shouldPassValidation_whenNuclearChromosomeOmitsLocation() {
-            // Per the ENA assembly submission docs, a nuclear chromosome is expressed by omitting
-            // chromosome_location entirely -- name + type alone is a valid combination.
-            FastaHeader h = validHeader();
-            h.setChromosomeName("1");
-            h.setChromosomeType("chromosome");
-
-            List<String> errors = FastaHeaderFormatValidation.validate(h);
-
-            assertTrue(errors.isEmpty());
-        }
-
-        @Test
-        void shouldFail_whenChromosomeLocationIsLiteralNuclear() {
-            // "nuclear" is not part of the INSDC /organelle vocabulary, so validate() alone rejects
-            // it as an invalid value; FastaHeaderNormalisationFix strips it to null upstream of
-            // validation in the real pipeline (see FastaHeaderNormalisationFixTest).
+        void shouldPassValidation_whenChromosomeLocationIsNuclear() {
+            // "Nuclear" is an allowed value denoting the nuclear/cytoplasmic default; per the team
+            // decision chromosome_location is mandatory for a chromosome, so all three fields are set.
             FastaHeader h = validHeader();
             h.setChromosomeName("1");
             h.setChromosomeType("chromosome");
@@ -265,7 +251,20 @@ public class FastaHeaderFormatValidationTest {
 
             List<String> errors = FastaHeaderFormatValidation.validate(h);
 
-            assertTrue(errors.contains("invalid chromosome_location - see allowed values list"));
+            assertTrue(errors.isEmpty());
+        }
+
+        @Test
+        void shouldFail_whenNuclearChromosomeOmitsLocation() {
+            // chromosome_location is mandatory when a chromosome is described (name + type present),
+            // so omitting it is an invalid combination even for a nuclear chromosome.
+            FastaHeader h = validHeader();
+            h.setChromosomeName("1");
+            h.setChromosomeType("chromosome");
+
+            List<String> errors = FastaHeaderFormatValidation.validate(h);
+
+            assertTrue(errors.stream().anyMatch(e -> e.contains("invalid combination of optional chromosome fields")));
         }
 
         @Test
@@ -329,12 +328,11 @@ public class FastaHeaderFormatValidationTest {
     }
 
     /**
-     * Covers the allowed combinations of the optional chromosome fields, mirroring the ENA Chromosome
-     * List File column structure: none present (unplaced contig), chromosome_name only (unlocalized),
-     * or chromosome_name + chromosome_type with chromosome_location optional on top (chromosome; a
-     * nuclear/cytoplasmic chromosome omits chromosome_location). Every other combination must be
-     * reported. Field values below are all individually valid so the combination rule is the only
-     * thing under test.
+     * Covers the allowed combinations of the optional chromosome fields. Per the team decision,
+     * chromosome_location is mandatory when a chromosome is described, so only three combinations are
+     * valid: none present (unplaced contig), chromosome_name only (unlocalized), or all three present
+     * (chromosome). Every other combination must be reported. Field values below are all individually
+     * valid so the combination rule is the only thing under test.
      */
     @Nested
     public class ChromosomeFieldCombinationTest {
@@ -358,13 +356,8 @@ public class FastaHeaderFormatValidationTest {
         }
 
         @Test
-        void shouldPass_whenAllThreeChromosomeFieldsPresent() { // table row 4: chromosome, explicit location
+        void shouldPass_whenAllThreeChromosomeFieldsPresent() { // table row 4: chromosome
             assertFalse(combinationErrors(NAME, TYPE, LOCATION).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
-        }
-
-        @Test
-        void shouldPass_whenChromosomeNameAndTypePresentWithoutLocation() { // table row 4: chromosome, nuclear default
-            assertFalse(combinationErrors(NAME, TYPE, null).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
         }
 
         // --- invalid combinations ---
@@ -387,6 +380,11 @@ public class FastaHeaderFormatValidationTest {
         @Test
         void shouldFail_whenChromosomeNameAndLocationPresentWithoutType() { // table row 3.b
             assertTrue(combinationErrors(NAME, null, LOCATION).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
+        }
+
+        @Test
+        void shouldFail_whenChromosomeNameAndTypePresentWithoutLocation() { // table row 3.c
+            assertTrue(combinationErrors(NAME, TYPE, null).stream().anyMatch(e -> e.contains(COMBINATION_ERROR)));
         }
 
         private List<String> combinationErrors(String name, String type, String location) {

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidationTest.java
@@ -76,6 +76,14 @@ public class FastaHeaderFormatValidationTest {
     }
 
     @Test
+    void validateDoesNotThrowWhenNoFastaHeaderProviderRegistered() {
+        // No FastaHeaderProvider on the context (e.g. a header-less conversion) -> nothing to validate.
+        when(context.contains(FastaHeaderProvider.class)).thenReturn(false);
+
+        assertDoesNotThrow(() -> validation.validate(annotation, LINE));
+    }
+
+    @Test
     void validateDoesNothingWhenFastaHeaderIsValid() {
         FastaHeader header = validHeader();
 

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderFormatValidationTest.java
@@ -241,13 +241,13 @@ public class FastaHeaderFormatValidationTest {
         }
 
         @Test
-        void shouldPassValidation_whenChromosomeLocationIsNuclear() {
-            // "Nuclear" is an allowed value denoting the nuclear/cytoplasmic default; per the team
+        void shouldPassValidation_whenChromosomeLocationIsNucleus() {
+            // "Nucleus"/"Cytoplasm" are allowed values denoting the default location; per the team
             // decision chromosome_location is mandatory for a chromosome, so all three fields are set.
             FastaHeader h = validHeader();
             h.setChromosomeName("1");
             h.setChromosomeType("chromosome");
-            h.setChromosomeLocation("Nuclear");
+            h.setChromosomeLocation("Nucleus");
 
             List<String> errors = FastaHeaderFormatValidation.validate(h);
 
@@ -255,9 +255,21 @@ public class FastaHeaderFormatValidationTest {
         }
 
         @Test
-        void shouldFail_whenNuclearChromosomeOmitsLocation() {
+        void shouldPassValidation_whenChromosomeLocationIsCytoplasm() {
+            FastaHeader h = validHeader();
+            h.setChromosomeName("1");
+            h.setChromosomeType("plasmid");
+            h.setChromosomeLocation("Cytoplasm");
+
+            List<String> errors = FastaHeaderFormatValidation.validate(h);
+
+            assertTrue(errors.isEmpty());
+        }
+
+        @Test
+        void shouldFail_whenChromosomeOmitsLocation() {
             // chromosome_location is mandatory when a chromosome is described (name + type present),
-            // so omitting it is an invalid combination even for a nuclear chromosome.
+            // so omitting it is an invalid combination even for the default location.
             FastaHeader h = validHeader();
             h.setChromosomeName("1");
             h.setChromosomeType("chromosome");

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderMappingValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderMappingValidationTest.java
@@ -67,8 +67,8 @@ class FastaHeaderMappingValidationTest {
     void throwsWhenProviderHasNoHeaderForAccession() {
         when(fastaHeaderProvider.getHeader(ACCESSION)).thenReturn(Optional.empty());
 
-        ValidationException exception = assertThrows(
-                ValidationException.class, () -> validation.validateFastaHeaderMapping(annotation, LINE));
+        ValidationException exception =
+                assertThrows(ValidationException.class, () -> validation.validateFastaHeaderMapping(annotation, LINE));
 
         String message = exception.getMessage();
         assertTrue(message.contains("FASTA_HEADER_MAPPING"));

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderMappingValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/FastaHeaderMappingValidationTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.validation.builtin;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
+import uk.ac.ebi.embl.gff3tools.validation.ValidationContext;
+
+class FastaHeaderMappingValidationTest {
+
+    private static final int LINE = 42;
+    private static final String ACCESSION = "CM000001.1";
+
+    private FastaHeaderMappingValidation validation;
+    private ValidationContext context;
+    private FastaHeaderProvider fastaHeaderProvider;
+    private GFF3Annotation annotation;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        validation = new FastaHeaderMappingValidation();
+        context = mock(ValidationContext.class);
+        fastaHeaderProvider = mock(FastaHeaderProvider.class);
+        annotation = mock(GFF3Annotation.class);
+
+        when(context.contains(FastaHeaderProvider.class)).thenReturn(true);
+        when(context.get(FastaHeaderProvider.class)).thenReturn(fastaHeaderProvider);
+        when(annotation.getAccession()).thenReturn(ACCESSION);
+
+        injectContext(validation, context);
+    }
+
+    @Test
+    void doesNotThrowWhenNoFastaHeaderProviderRegistered() {
+        // No FastaHeaderProvider on the context (e.g. a header-less conversion) -> nothing to map.
+        when(context.contains(FastaHeaderProvider.class)).thenReturn(false);
+
+        assertDoesNotThrow(() -> validation.validateFastaHeaderMapping(annotation, LINE));
+    }
+
+    @Test
+    void doesNotThrowWhenHeaderResolvesForAccession() {
+        when(fastaHeaderProvider.getHeader(ACCESSION)).thenReturn(Optional.of(new FastaHeader()));
+
+        assertDoesNotThrow(() -> validation.validateFastaHeaderMapping(annotation, LINE));
+    }
+
+    @Test
+    void throwsWhenProviderHasNoHeaderForAccession() {
+        when(fastaHeaderProvider.getHeader(ACCESSION)).thenReturn(Optional.empty());
+
+        ValidationException exception = assertThrows(
+                ValidationException.class, () -> validation.validateFastaHeaderMapping(annotation, LINE));
+
+        String message = exception.getMessage();
+        assertTrue(message.contains("FASTA_HEADER_MAPPING"));
+        assertTrue(message.contains(ACCESSION));
+        assertEquals(LINE, exception.getLine());
+    }
+
+    private static void injectContext(FastaHeaderMappingValidation validation, ValidationContext context)
+            throws Exception {
+        Field field = FastaHeaderMappingValidation.class.getDeclaredField("context");
+        field.setAccessible(true);
+        field.set(validation, context);
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/MoleculeTypeValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/MoleculeTypeValidationTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.validation.builtin;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Feature;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
+import uk.ac.ebi.embl.gff3tools.utils.OntologyClient;
+import uk.ac.ebi.embl.gff3tools.utils.OntologyTerm;
+import uk.ac.ebi.embl.gff3tools.validation.ValidationContext;
+
+class MoleculeTypeValidationTest {
+
+    private static final int LINE = 42;
+    private static final String ACCESSION = "CM000001.1";
+
+    private MoleculeTypeValidation validation;
+    private FastaHeaderProvider fastaHeaderProvider;
+    private OntologyClient ontologyClient;
+    private GFF3Annotation annotation;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        validation = new MoleculeTypeValidation();
+        ValidationContext context = mock(ValidationContext.class);
+        fastaHeaderProvider = mock(FastaHeaderProvider.class);
+        ontologyClient = mock(OntologyClient.class);
+        annotation = mock(GFF3Annotation.class);
+
+        when(context.get(FastaHeaderProvider.class)).thenReturn(fastaHeaderProvider);
+        when(context.get(OntologyClient.class)).thenReturn(ontologyClient);
+        when(annotation.getAccession()).thenReturn(ACCESSION);
+
+        injectContext(validation, context);
+    }
+
+    @Nested
+    class ValidateRequiredFeature {
+
+        @Test
+        void doesNothingWhenMoleculeTypeDoesNotRequireAFeature() {
+            when(fastaHeaderProvider.getHeader(ACCESSION))
+                    .thenReturn(Optional.of(headerWithMoleculeType("genomic DNA")));
+
+            assertDoesNotThrow(() -> validation.validateRequiredFeature(annotation, LINE));
+        }
+
+        @Test
+        void doesNothingWhenRequiredFeatureIsPresent() {
+            GFF3Feature feature = feature("ribosomal RNA");
+            when(annotation.getFeatures()).thenReturn(List.of(feature));
+            when(fastaHeaderProvider.getHeader(ACCESSION)).thenReturn(Optional.of(headerWithMoleculeType("rRNA")));
+            when(ontologyClient.findTermByNameOrSynonym("ribosomal RNA")).thenReturn(Optional.of(OntologyTerm.RRNA.ID));
+            when(ontologyClient.isSelfOrDescendantOf(OntologyTerm.RRNA.ID, OntologyTerm.RRNA.ID))
+                    .thenReturn(true);
+
+            assertDoesNotThrow(() -> validation.validateRequiredFeature(annotation, LINE));
+        }
+
+        @Test
+        void throwsValidationExceptionWhenRequiredFeatureIsMissing() {
+            GFF3Feature feature = feature("gene");
+            when(annotation.getFeatures()).thenReturn(List.of(feature));
+            when(fastaHeaderProvider.getHeader(ACCESSION)).thenReturn(Optional.of(headerWithMoleculeType("tRNA")));
+            when(ontologyClient.findTermByNameOrSynonym("gene")).thenReturn(Optional.of(OntologyTerm.GENE.ID));
+            when(ontologyClient.isSelfOrDescendantOf(OntologyTerm.GENE.ID, OntologyTerm.TRNA.ID))
+                    .thenReturn(false);
+
+            ValidationException exception =
+                    assertThrows(ValidationException.class, () -> validation.validateRequiredFeature(annotation, LINE));
+
+            String message = exception.getMessage();
+            assertTrue(message.contains(MoleculeTypeValidation.REQUIRED_FEATURE_RULE));
+            assertTrue(message.contains("Feature TRNA is required when molecule type is TRNA."));
+        }
+    }
+
+    @Nested
+    class ValidateMrnaCdsComplement {
+
+        @Test
+        void doesNothingWhenEntryIsNotMrna() {
+            GFF3Feature complementCds = feature("CDS", true);
+            when(annotation.getFeatures()).thenReturn(List.of(complementCds));
+            when(fastaHeaderProvider.getHeader(ACCESSION))
+                    .thenReturn(Optional.of(headerWithMoleculeType("genomic DNA")));
+
+            assertDoesNotThrow(() -> validation.validateMrnaCdsComplement(annotation, LINE));
+        }
+
+        @Test
+        void doesNothingWhenMrnaCdsIsNotComplement() {
+            GFF3Feature cds = feature("CDS", false);
+            when(annotation.getFeatures()).thenReturn(List.of(cds));
+            when(fastaHeaderProvider.getHeader(ACCESSION)).thenReturn(Optional.of(headerWithMoleculeType("mRNA")));
+            when(ontologyClient.findTermByNameOrSynonym("CDS")).thenReturn(Optional.of(OntologyTerm.CDS.ID));
+
+            assertDoesNotThrow(() -> validation.validateMrnaCdsComplement(annotation, LINE));
+        }
+
+        @Test
+        void throwsValidationExceptionWhenMrnaCdsIsComplement() {
+            GFF3Feature complementCds = feature("CDS", true);
+            when(annotation.getFeatures()).thenReturn(List.of(complementCds));
+            when(fastaHeaderProvider.getHeader(ACCESSION)).thenReturn(Optional.of(headerWithMoleculeType("mRNA")));
+            when(ontologyClient.findTermByNameOrSynonym("CDS")).thenReturn(Optional.of(OntologyTerm.CDS.ID));
+
+            ValidationException exception = assertThrows(
+                    ValidationException.class, () -> validation.validateMrnaCdsComplement(annotation, LINE));
+
+            String message = exception.getMessage();
+            assertTrue(message.contains(MoleculeTypeValidation.MRNA_CDS_COMPLEMENT_RULE));
+            assertTrue(message.contains("Complement locations are not permitted in CDS features on mRNA entries."));
+        }
+    }
+
+    private static GFF3Feature feature(String name) {
+        return feature(name, false);
+    }
+
+    private static GFF3Feature feature(String name, boolean complement) {
+        GFF3Feature feature = mock(GFF3Feature.class);
+        when(feature.getName()).thenReturn(name);
+        when(feature.isComplement()).thenReturn(complement);
+        return feature;
+    }
+
+    private static FastaHeader headerWithMoleculeType(String moleculeType) {
+        FastaHeader header = new FastaHeader();
+        header.setMoleculeType(moleculeType);
+        return header;
+    }
+
+    private static void injectContext(MoleculeTypeValidation validation, ValidationContext context) throws Exception {
+        Field field = MoleculeTypeValidation.class.getDeclaredField("context");
+        field.setAccessible(true);
+        field.set(validation, context);
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/MoleculeTypeValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/MoleculeTypeValidationTest.java
@@ -50,6 +50,7 @@ class MoleculeTypeValidationTest {
         ontologyClient = mock(OntologyClient.class);
         annotation = mock(GFF3Annotation.class);
 
+        when(context.contains(FastaHeaderProvider.class)).thenReturn(true);
         when(context.get(FastaHeaderProvider.class)).thenReturn(fastaHeaderProvider);
         when(context.get(OntologyClient.class)).thenReturn(ontologyClient);
         when(annotation.getAccession()).thenReturn(ACCESSION);

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/MoleculeTypeValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/MoleculeTypeValidationTest.java
@@ -38,6 +38,7 @@ class MoleculeTypeValidationTest {
     private static final String ACCESSION = "CM000001.1";
 
     private MoleculeTypeValidation validation;
+    private ValidationContext context;
     private FastaHeaderProvider fastaHeaderProvider;
     private OntologyClient ontologyClient;
     private GFF3Annotation annotation;
@@ -45,7 +46,7 @@ class MoleculeTypeValidationTest {
     @BeforeEach
     void setUp() throws Exception {
         validation = new MoleculeTypeValidation();
-        ValidationContext context = mock(ValidationContext.class);
+        context = mock(ValidationContext.class);
         fastaHeaderProvider = mock(FastaHeaderProvider.class);
         ontologyClient = mock(OntologyClient.class);
         annotation = mock(GFF3Annotation.class);
@@ -135,6 +136,27 @@ class MoleculeTypeValidationTest {
             String message = exception.getMessage();
             assertTrue(message.contains(MoleculeTypeValidation.MRNA_CDS_COMPLEMENT_RULE));
             assertTrue(message.contains("Complement locations are not permitted in CDS features on mRNA entries."));
+        }
+    }
+
+    @Nested
+    class NoFastaHeaderProvider {
+
+        // When no FastaHeaderProvider is registered (e.g. a header-less conversion), the molecule
+        // type cannot be resolved, so neither validation method should throw.
+        @BeforeEach
+        void noProvider() {
+            when(context.contains(FastaHeaderProvider.class)).thenReturn(false);
+        }
+
+        @Test
+        void validateRequiredFeatureDoesNotThrow() {
+            assertDoesNotThrow(() -> validation.validateRequiredFeature(annotation, LINE));
+        }
+
+        @Test
+        void validateMrnaCdsComplementDoesNotThrow() {
+            assertDoesNotThrow(() -> validation.validateMrnaCdsComplement(annotation, LINE));
         }
     }
 

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/ChromosomeNameFixTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/ChromosomeNameFixTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.validation.fix;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import uk.ac.ebi.embl.gff3tools.TestUtils;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Feature;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderSource;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
+import uk.ac.ebi.embl.gff3tools.validation.ValidationContext;
+
+public class ChromosomeNameFixTest {
+
+    private static final String ACCESSION = "ACC1";
+
+    private ChromosomeNameFix fix;
+
+    @BeforeEach
+    public void setUp() {
+        fix = new ChromosomeNameFix();
+    }
+
+    /**
+     * Wires the fix with a context exposing a single header (keyed by {@link #ACCESSION}) carrying the
+     * given chromosome name, runs the fix against a matching annotation, and returns the (possibly)
+     * normalised chromosome name.
+     */
+    private String runFix(String chromosomeName) {
+        FastaHeader header = new FastaHeader();
+        header.setChromosomeName(chromosomeName);
+        injectContextWithHeaders(Map.of(ACCESSION, header));
+
+        fix.fix(annotationFor(ACCESSION), 1);
+        return header.getChromosomeName();
+    }
+
+    private void injectContextWithHeaders(Map<String, FastaHeader> headersByAccession) {
+        FastaHeaderProvider provider = new FastaHeaderProvider();
+        provider.addSource(new FastaHeaderSource() {
+            @Override
+            public Optional<FastaHeader> getHeader(String seqId) {
+                return Optional.ofNullable(headersByAccession.get(seqId));
+            }
+        });
+        ValidationContext context = new ValidationContext();
+        context.register(FastaHeaderProvider.class, provider);
+        TestUtils.injectContext(fix, context);
+    }
+
+    private GFF3Annotation annotationFor(String accession) {
+        GFF3Annotation annotation = new GFF3Annotation();
+        GFF3Feature feature = TestUtils.createGFF3Feature("CDS", accession, 1L, 10L, new HashMap<>());
+        annotation.addFeature(feature);
+        return annotation;
+    }
+
+    @Test
+    public void removesWhitespace() {
+        assertEquals("1A2B", runFix(" 1A\t2B \n"));
+    }
+
+    @Test
+    public void replacesIllegalCharactersWithUnderscore() {
+        assertEquals("a_b_c_d_e_f", runFix("a\\b/c|d=e;f"));
+    }
+
+    @Test
+    public void trimsLeadingAndTrailingUnderscores() {
+        assertEquals("name", runFix("___name___"));
+    }
+
+    @Test
+    public void collapsesDuplicateUnderscoreRuns() {
+        assertEquals("a_b_c", runFix("a__b___c"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "chromosome1, 1",
+        "CHROMOSOME1, 1",
+        "chrom1, 1",
+        "CHROM1, 1",
+        "chrm1, 1",
+        "chr1, 1",
+        "CHR1, 1",
+        "Chromosome 1, 1",
+    })
+    public void removesChromosomeKeywords(String input, String expected) {
+        assertEquals(expected, runFix(input));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "linkage-group3, 3",
+        "linkage group3, 3",
+        "LINKAGE-GROUP3, 3",
+        "Linkage Group 3, 3",
+    })
+    public void removesLinkageGroupKeywords(String input, String expected) {
+        assertEquals(expected, runFix(input));
+    }
+
+    @Test
+    public void removesPlasmidKeyword() {
+        assertEquals("A", runFix("plasmidA"));
+    }
+
+    @Test
+    public void removesPlasmidKeywordCaseInsensitive() {
+        assertEquals("A", runFix("PLASMID A"));
+    }
+
+    @Test
+    public void preservesPlasmidWithinMegaplasmid() {
+        assertEquals("megaplasmid1", runFix("megaplasmid 1"));
+    }
+
+    @Test
+    public void appliesAllRulesCombined() {
+        // whitespace + keyword removal + illegal chars + collapse + trim
+        assertEquals("1_A", runFix("  chromosome 1 |= A  "));
+    }
+
+    @Test
+    public void leavesAlreadyCleanNameUnchanged() {
+        assertEquals("scaffold42", runFix("scaffold42"));
+    }
+
+    @Test
+    public void leavesNullChromosomeNameUnchanged() {
+        assertNull(runFix(null));
+    }
+
+    @Test
+    public void ignoresAnnotationWhenNoHeaderRegisteredForAccession() {
+        injectContextWithHeaders(Map.of());
+        assertDoesNotThrow(() -> fix.fix(annotationFor(ACCESSION), 1));
+    }
+
+    @Test
+    public void ignoresAnnotationWhenNoFastaHeaderProviderRegistered() {
+        TestUtils.injectContext(fix, new ValidationContext());
+        assertDoesNotThrow(() -> fix.fix(annotationFor(ACCESSION), 1));
+    }
+}

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFixTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFixTest.java
@@ -41,7 +41,7 @@ public class FastaHeaderNormalisationFixTest {
     /** Wires the fix with a context exposing the given header, runs the vocabulary fix, and returns it. */
     private FastaHeader runVocabularyFix(FastaHeader header) {
         injectContextWithHeaders(Map.of(ACCESSION, header));
-        fix.ControlledVocabularyNormalisation(annotationFor(ACCESSION), 1);
+        fix.normaliseHeaderValues(annotationFor(ACCESSION), 1);
         return header;
     }
 
@@ -144,15 +144,105 @@ public class FastaHeaderNormalisationFixTest {
         assertNull(result.getChromosomeLocation());
     }
 
+    // ----------------------- ASCII7 folding edge cases -----------------------
+
+    @Test
+    public void foldsDiacriticsThenMatchesVocabulary() {
+        // ASCII folding (é -> e) runs first, letting the value match the controlled vocabulary.
+        FastaHeader header = new FastaHeader();
+        header.setMoleculeType("génomic DNA");
+        assertEquals("genomic DNA", runVocabularyFix(header).getMoleculeType());
+    }
+
+    @Test
+    public void foldsDiacriticsCaseAndDashTogether() {
+        // Diacritic (ñ -> n) + dash->underscore + case-insensitive match all compose.
+        FastaHeader header = new FastaHeader();
+        header.setChromosomeType("Liñkage-Group");
+        assertEquals("linkage_group", runVocabularyFix(header).getChromosomeType());
+    }
+
+    @Test
+    public void foldsTopologyDiacriticAndCase() {
+        FastaHeader header = new FastaHeader();
+        header.setTopology("Línear");
+        assertEquals("linear", runVocabularyFix(header).getTopology());
+    }
+
+    @Test
+    public void replacesNonLatin1CharactersWithQuestionMark() {
+        // Characters beyond Latin-1 (here Greek alpha) become '?'.
+        FastaHeader header = new FastaHeader();
+        header.setDescription("Genome α");
+        assertEquals("Genome ?", runVocabularyFix(header).getDescription());
+    }
+
+    @Test
+    public void replacesSmartQuoteWithQuestionMark() {
+        FastaHeader header = new FastaHeader();
+        header.setDescription("John’s genome");
+        assertEquals("John?s genome", runVocabularyFix(header).getDescription());
+    }
+
+    @Test
+    public void mapsSpecialLatinLettersToAscii() {
+        // Æ -> A and ß -> s via the converter's explicit character mapping.
+        FastaHeader header = new FastaHeader();
+        header.setDescription("Ælfred Straße");
+        assertEquals("Alfred Strase", runVocabularyFix(header).getDescription());
+    }
+
+    @Test
+    public void stripsNonPrintableControlCharacters() {
+        // A lone ASCII control char (BEL, 0x07) triggers conversion and is stripped.
+        FastaHeader header = new FastaHeader();
+        header.setDescription("abcd");
+        assertEquals("abcd", runVocabularyFix(header).getDescription());
+    }
+
+    @Test
+    public void foldsChromosomeNameEvenThoughItIsNotControlledVocabulary() {
+        FastaHeader header = new FastaHeader();
+        header.setChromosomeName("chrömosome1");
+        assertEquals("chromosome1", runVocabularyFix(header).getChromosomeName());
+    }
+
+    @Test
+    public void leavesCleanAsciiValuesUnchanged() {
+        FastaHeader header = new FastaHeader();
+        header.setDescription("Plain text 123");
+        header.setMoleculeType("genomic DNA");
+        FastaHeader result = runVocabularyFix(header);
+        assertEquals("Plain text 123", result.getDescription());
+        assertEquals("genomic DNA", result.getMoleculeType());
+    }
+
+    @Test
+    public void leavesEmptyStringUnchanged() {
+        FastaHeader header = new FastaHeader();
+        header.setMoleculeType("");
+        assertEquals("", runVocabularyFix(header).getMoleculeType());
+    }
+
+    @Test
+    public void leavesNonVocabularyValueWithInternalWhitespaceUntouched() {
+        // canonicalise only trims edges; an unmatched value keeps its internal spacing.
+        FastaHeader header = new FastaHeader();
+        header.setChromosomeType("not a type");
+        assertEquals("not a type", runVocabularyFix(header).getChromosomeType());
+    }
+
+    // ----------------------------- guard cases -------------------------------
+
     @Test
     public void ignoresAnnotationWhenNoHeaderRegisteredForAccession() {
         injectContextWithHeaders(Map.of());
-        assertDoesNotThrow(() -> fix.ControlledVocabularyNormalisation(annotationFor(ACCESSION), 1));
+        assertDoesNotThrow(() -> fix.normaliseHeaderValues(annotationFor(ACCESSION), 1));
     }
 
     @Test
     public void ignoresAnnotationWhenNoFastaHeaderProviderRegistered() {
         TestUtils.injectContext(fix, new ValidationContext());
-        assertDoesNotThrow(() -> fix.ControlledVocabularyNormalisation(annotationFor(ACCESSION), 1));
+        assertDoesNotThrow(() -> fix.normaliseHeaderValues(annotationFor(ACCESSION), 1));
     }
 }

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFixTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFixTest.java
@@ -87,19 +87,19 @@ public class FastaHeaderNormalisationFixTest {
     }
 
     @Test
-    public void normalisesNuclearChromosomeLocationToAbsent() {
-        // "nuclear" is not part of the INSDC /organelle vocabulary -- per the ENA assembly
-        // submission docs, a nuclear chromosome_location is expressed by omitting the field.
+    public void normalisesNuclearChromosomeLocationCase() {
+        // "Nuclear" is an allowed value (gff3tools extension of the INSDC /organelle list) used to
+        // express the nuclear/cytoplasmic default explicitly; it canonicalises like any other value.
         FastaHeader header = new FastaHeader();
         header.setChromosomeLocation("nuclear");
-        assertNull(runVocabularyFix(header).getChromosomeLocation());
+        assertEquals("Nuclear", runVocabularyFix(header).getChromosomeLocation());
     }
 
     @Test
-    public void normalisesNuclearChromosomeLocationToAbsentRegardlessOfCase() {
+    public void normalisesNuclearChromosomeLocationRegardlessOfCase() {
         FastaHeader header = new FastaHeader();
         header.setChromosomeLocation("NUCLEAR");
-        assertNull(runVocabularyFix(header).getChromosomeLocation());
+        assertEquals("Nuclear", runVocabularyFix(header).getChromosomeLocation());
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFixTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFixTest.java
@@ -87,19 +87,19 @@ public class FastaHeaderNormalisationFixTest {
     }
 
     @Test
-    public void normalisesNuclearChromosomeLocationCase() {
-        // "Nuclear" is an allowed value (gff3tools extension of the INSDC /organelle list) used to
-        // express the nuclear/cytoplasmic default explicitly; it canonicalises like any other value.
+    public void normalisesNucleusChromosomeLocationCase() {
+        // "Nucleus"/"Cytoplasm" are allowed values (gff3tools extensions of the INSDC /organelle
+        // list) for the default location; they canonicalise like any other value.
         FastaHeader header = new FastaHeader();
-        header.setChromosomeLocation("nuclear");
-        assertEquals("Nuclear", runVocabularyFix(header).getChromosomeLocation());
+        header.setChromosomeLocation("nucleus");
+        assertEquals("Nucleus", runVocabularyFix(header).getChromosomeLocation());
     }
 
     @Test
-    public void normalisesNuclearChromosomeLocationRegardlessOfCase() {
+    public void normalisesCytoplasmChromosomeLocationRegardlessOfCase() {
         FastaHeader header = new FastaHeader();
-        header.setChromosomeLocation("NUCLEAR");
-        assertEquals("Nuclear", runVocabularyFix(header).getChromosomeLocation());
+        header.setChromosomeLocation("CYTOPLASM");
+        assertEquals("Cytoplasm", runVocabularyFix(header).getChromosomeLocation());
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFixTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFixTest.java
@@ -87,6 +87,22 @@ public class FastaHeaderNormalisationFixTest {
     }
 
     @Test
+    public void normalisesNuclearChromosomeLocationToAbsent() {
+        // "nuclear" is not part of the INSDC /organelle vocabulary -- per the ENA assembly
+        // submission docs, a nuclear chromosome_location is expressed by omitting the field.
+        FastaHeader header = new FastaHeader();
+        header.setChromosomeLocation("nuclear");
+        assertNull(runVocabularyFix(header).getChromosomeLocation());
+    }
+
+    @Test
+    public void normalisesNuclearChromosomeLocationToAbsentRegardlessOfCase() {
+        FastaHeader header = new FastaHeader();
+        header.setChromosomeLocation("NUCLEAR");
+        assertNull(runVocabularyFix(header).getChromosomeLocation());
+    }
+
+    @Test
     public void normalisesChromosomeTypeDashAndCase() {
         FastaHeader header = new FastaHeader();
         header.setChromosomeType("Linkage-Group");

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFixTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/FastaHeaderNormalisationFixTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.validation.fix;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.gff3tools.TestUtils;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Feature;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderProvider;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.FastaHeaderSource;
+import uk.ac.ebi.embl.gff3tools.sequence.fasta.header.utils.FastaHeader;
+import uk.ac.ebi.embl.gff3tools.validation.ValidationContext;
+
+public class FastaHeaderNormalisationFixTest {
+
+    private static final String ACCESSION = "ACC1";
+
+    private FastaHeaderNormalisationFix fix;
+
+    @BeforeEach
+    public void setUp() {
+        fix = new FastaHeaderNormalisationFix();
+    }
+
+    /** Wires the fix with a context exposing the given header, runs the vocabulary fix, and returns it. */
+    private FastaHeader runVocabularyFix(FastaHeader header) {
+        injectContextWithHeaders(Map.of(ACCESSION, header));
+        fix.ControlledVocabularyNormalisation(annotationFor(ACCESSION), 1);
+        return header;
+    }
+
+    private void injectContextWithHeaders(Map<String, FastaHeader> headersByAccession) {
+        FastaHeaderProvider provider = new FastaHeaderProvider();
+        provider.addSource(new FastaHeaderSource() {
+            @Override
+            public Optional<FastaHeader> getHeader(String seqId) {
+                return Optional.ofNullable(headersByAccession.get(seqId));
+            }
+        });
+        ValidationContext context = new ValidationContext();
+        context.register(FastaHeaderProvider.class, provider);
+        TestUtils.injectContext(fix, context);
+    }
+
+    private GFF3Annotation annotationFor(String accession) {
+        GFF3Annotation annotation = new GFF3Annotation();
+        GFF3Feature feature = TestUtils.createGFF3Feature("CDS", accession, 1L, 10L, new HashMap<>());
+        annotation.addFeature(feature);
+        return annotation;
+    }
+
+    @Test
+    public void normalisesMoleculeTypeCase() {
+        FastaHeader header = new FastaHeader();
+        header.setMoleculeType("GENOMIC DNA");
+        assertEquals("genomic DNA", runVocabularyFix(header).getMoleculeType());
+    }
+
+    @Test
+    public void normalisesTopologyCase() {
+        FastaHeader header = new FastaHeader();
+        header.setTopology("Circular");
+        assertEquals("circular", runVocabularyFix(header).getTopology());
+    }
+
+    @Test
+    public void normalisesChromosomeLocationCase() {
+        FastaHeader header = new FastaHeader();
+        header.setChromosomeLocation("mitochondrion");
+        assertEquals("Mitochondrion", runVocabularyFix(header).getChromosomeLocation());
+    }
+
+    @Test
+    public void normalisesChromosomeTypeDashAndCase() {
+        FastaHeader header = new FastaHeader();
+        header.setChromosomeType("Linkage-Group");
+        assertEquals("linkage_group", runVocabularyFix(header).getChromosomeType());
+    }
+
+    @Test
+    public void trimsEdgeWhitespaceBeforeMatching() {
+        FastaHeader header = new FastaHeader();
+        header.setTopology("  linear \t");
+        assertEquals("linear", runVocabularyFix(header).getTopology());
+    }
+
+    @Test
+    public void normalisesAllVocabularyFieldsTogether() {
+        FastaHeader header = new FastaHeader();
+        header.setMoleculeType("mrna");
+        header.setTopology("LINEAR");
+        header.setChromosomeType("plasmid");
+        header.setChromosomeLocation("CHLOROPLAST");
+
+        FastaHeader result = runVocabularyFix(header);
+
+        assertEquals("mRNA", result.getMoleculeType());
+        assertEquals("linear", result.getTopology());
+        assertEquals("plasmid", result.getChromosomeType());
+        assertEquals("Chloroplast", result.getChromosomeLocation());
+    }
+
+    @Test
+    public void leavesDescriptionUntouched() {
+        FastaHeader header = new FastaHeader();
+        header.setDescription("My Genomic DNA Sample");
+        header.setMoleculeType("genomic DNA");
+        assertEquals("My Genomic DNA Sample", runVocabularyFix(header).getDescription());
+    }
+
+    @Test
+    public void leavesUnknownValuesUntouched() {
+        FastaHeader header = new FastaHeader();
+        header.setMoleculeType("DNA");
+        header.setTopology("triangle");
+        FastaHeader result = runVocabularyFix(header);
+        assertEquals("DNA", result.getMoleculeType());
+        assertEquals("triangle", result.getTopology());
+    }
+
+    @Test
+    public void leavesNullFieldsUntouched() {
+        FastaHeader header = new FastaHeader();
+        header.setMoleculeType("genomic DNA");
+        FastaHeader result = runVocabularyFix(header);
+        assertNull(result.getTopology());
+        assertNull(result.getChromosomeType());
+        assertNull(result.getChromosomeLocation());
+    }
+
+    @Test
+    public void ignoresAnnotationWhenNoHeaderRegisteredForAccession() {
+        injectContextWithHeaders(Map.of());
+        assertDoesNotThrow(() -> fix.ControlledVocabularyNormalisation(annotationFor(ACCESSION), 1));
+    }
+
+    @Test
+    public void ignoresAnnotationWhenNoFastaHeaderProviderRegistered() {
+        TestUtils.injectContext(fix, new ValidationContext());
+        assertDoesNotThrow(() -> fix.ControlledVocabularyNormalisation(annotationFor(ACCESSION), 1));
+    }
+}

--- a/src/test/resources/fasta_to_gff3/single_sequence.fasta
+++ b/src/test/resources/fasta_to_gff3/single_sequence.fasta
@@ -1,4 +1,4 @@
->TEST01.1 | {"description":"Test sequence with gaps"}
+>TEST01.1 | {"description":"Test sequence with gaps", "molecule_type":"genomic DNA", "topology":"linear"}
 ATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGC
 NNNNNNNNNN
 ATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGC

--- a/src/test/resources/fasta_to_gff3/single_sequence.fasta
+++ b/src/test/resources/fasta_to_gff3/single_sequence.fasta
@@ -1,4 +1,4 @@
->TEST01.1 | {"description":"Test sequence with gaps", "molecule_type":"genomic DNA", "topology":"linear"}
+>TEST01.1 | {"description":"Test sequence with gaps", "molecule_type":"GENOMIC DNA", "topology":"linear"}
 ATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGC
 NNNNNNNNNN
 ATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGC

--- a/src/test/resources/metadata/master_entry.json
+++ b/src/test/resources/metadata/master_entry.json
@@ -19,7 +19,7 @@
   "comment": "This is a test assembly",
   "chromosomeName": "chr1",
   "chromosomeType": "Chromosome",
-  "chromosomeLocation": "Nuclear",
+  "chromosomeLocation": "Nucleus",
   "firstPublic": "15-JAN-2024",
   "firstPublicRelease": 144,
   "lastUpdated": "01-JUN-2024",

--- a/src/test/resources/sequence/fasta/header_chromosome.json
+++ b/src/test/resources/sequence/fasta/header_chromosome.json
@@ -3,6 +3,6 @@
   "molecule_type": "genomic DNA",
   "topology": "linear",
   "chromosome_type": "Chromosome",
-  "chromosome_location": "Nuclear",
+  "chromosome_location": "Nucleus",
   "chromosome_name": "1"
 }


### PR DESCRIPTION
Moves GFF3 validations into this package and adds new FASTA-header fixes and validations. See the [[tracking sheet](https://docs.google.com/spreadsheets/d/1WOoOg-k2vrWpiH4T2NHIcJHYSSH9inOy-0AwPBNPlTI/edit?gid=1978204027#gid=1978204027)](https://docs.google.com/spreadsheets/d/1WOoOg-k2vrWpiH4T2NHIcJHYSSH9inOy-0AwPBNPlTI/edit?gid=1978204027#gid=1978204027) for the full list.

> **Note for reviewers:** the moved validations, their tests, and the controlled-vocabulary utils were *already reviewed elsewhere* and **can be skipped**. Focus review on the new fixes/validations and the `excludeProvider` wiring below.

## Moved code

- Moved validations + their tests + controlled-vocabulary utils over from the gff3 validations package.

## New fixes

- **`FastaHeaderNormalisationFix`** — *high priority*, runs as an annotation fix. Makes the FASTA header ASCII-compliant (as in `sequencetools`), then normalises the controlled-vocabulary fields (`topology`, `mol_type`, `chrom_location`, `chrom_type`) to the expected format. *Confirmed with Colman that we **should** do this* to give submitters some flexibility.
- **`ChromosomeNameFix`** — additional cleaning approved for **chromosome names only**:
  - trims **all** whitespace (not just edges)
  - removes certain words and ASCII alphabet signs
  - collapses duplicate dashes
  - etc.

## New validation

- **`FastaHeaderMappingValidation`** *(new annotation validation)* — raises an error when a `FastaHeaderProvider` **is** defined in the validation context but the header is unavailable. This lets all other fixes/validations simply `log.warn` when the provider is present but no header exists for a given annotation.
- *Added a test to every validation that uses the `FastaHeaderProvider`*, confirming it **does not throw** when the provider is `undefined`.

## FastaHeaderProvider auto-exclusion when not defined 

- Added an **`excludeProvider`** builder method to the validation engine to remove a single provider and prevent it from auto-registering (used in tests):

  ```java
  engineBuilder.excludeProvider(FastaHeaderProvider.class);
  ```

- `AbstractCommand.initValidationEngine` now auto-calls the above when no provider is explicitly supplied. As a result, FASTA-header-related fixes/validations only run *fully* when a CLI command supplies a provider with a real header source — otherwise they auto-return, since the relevant context is absent from the `ValidationContext`.
- Applied the same change to **`FileConversionCommand`** — *needs review*.
- Updated tests to use `excludeProvider` where applicable, **or** supplied a fully-defined `FastaHeaderProvider` (fixing the headers in those cases).

## Additional
Switched all FastaHeader-specific validations and fixes to critical. This is neccessary as the trimEdgeNs fix will need to query topology and and all other validations should work with those changed coordinates - so following the chain of dependedncies, if fastaheader is defined poorly in the FASTA file, that should blow up before the trimEdgeN fix and following validations. 

