### PR TITLE
MoleculeType Alias added

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 base {
     archivesName = 'gff3tools'
     group = 'uk.ac.ebi.ena'
-    version = '5.0.0'
+    version = '5.0.1'
 }
 
 java {

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/FastaHeader.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/sequence/fasta/header/utils/FastaHeader.java
@@ -22,7 +22,7 @@ public class FastaHeader {
     String description; // mandatory
 
     @JsonProperty("molecule_type")
-    @JsonAlias({"molecule-type", "molecule type", "moleculetype"})
+    @JsonAlias({"molecule-type", "molecule type", "moleculetype", "moleculeType"})
     String moleculeType; // mandatory
 
     @JsonProperty("topology")


### PR DESCRIPTION
Added the moleculeType alias to FastaHeader. Since webin-gff3-stages consumes gff3-service, it needs to be updated accordingly.