### PR TITLE
Ttena 279 - transl_except attribute value correction

### DIFF
--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/AttributesLocationValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/AttributesLocationValidation.java
@@ -22,11 +22,7 @@ import uk.ac.ebi.embl.gff3tools.translation.TranslationException;
 import uk.ac.ebi.embl.gff3tools.translation.except.AminoAcidExcept;
 import uk.ac.ebi.embl.gff3tools.translation.except.AntiCodonAttribute;
 import uk.ac.ebi.embl.gff3tools.translation.except.TranslExceptAttribute;
-import uk.ac.ebi.embl.gff3tools.validation.meta.Gff3Validation;
-import uk.ac.ebi.embl.gff3tools.validation.meta.RuleSeverity;
-import uk.ac.ebi.embl.gff3tools.validation.meta.Validation;
-import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationMethod;
-import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationType;
+import uk.ac.ebi.embl.gff3tools.validation.meta.*;
 
 @Gff3Validation(name = "ATTRIBUTES_LOCATION")
 public class AttributesLocationValidation implements Validation {
@@ -38,8 +34,6 @@ public class AttributesLocationValidation implements Validation {
     private static final String INVALID_LOCATION_SPAN = "%s location span must be \"%s\" at location %s";
     private static final String COMPLEMENT_STRAND_CONFLICT =
             "%s location is wrapped in complement() but the containing feature is on strand \"%s\": %s";
-    private static final String COMPLEMENT_UNRESOLVED =
-            "%s location is wrapped in complement() but does not fall within any feature fragment: %s";
 
     /** Detects a {@code complement(...)} wrapper that survived {@code TRANSL_EXCEPT_COMPLEMENT}. */
     private static final Pattern POS_COMPLEMENT_PATTERN =
@@ -54,7 +48,10 @@ public class AttributesLocationValidation implements Validation {
         validateCodonAttribute(grouped, ANTI_CODON, line);
     }
 
-    @ValidationMethod(rule = "TRANSL_EXCEPT_LOCATION", type = ValidationType.ANNOTATION)
+    @ValidationMethod(
+            rule = "TRANSL_EXCEPT_LOCATION",
+            type = ValidationType.ANNOTATION,
+            priority = ValidationPriority.HIGH)
     public void validateTranslExcept(GFF3Annotation gff3Annotation, int line) throws ValidationException {
         Map<String, List<GFF3Feature>> grouped = gff3Annotation.getFeatures().stream()
                 .filter(f -> f.hasAttribute(TRANSL_EXCEPT))
@@ -63,62 +60,44 @@ public class AttributesLocationValidation implements Validation {
         validateCodonAttribute(grouped, TRANSL_EXCEPT, line);
     }
 
-    /**
-     * Reports a {@code complement(...)} wrapper in a {@code transl_except} value whose direction the
-     * row's strand column does not confirm. {@code TRANSL_EXCEPT_COMPLEMENT} removes the wrapper
-     * when the two agree; when they disagree one of them is wrong, so this reports it rather than
-     * letting either side silently win.
-     */
     @ValidationMethod(
             rule = "TRANSL_EXCEPT_STRAND_CONFLICT",
-            type = ValidationType.ANNOTATION,
-            severity = RuleSeverity.WARN)
-    public void validateTranslExceptStrandConflict(GFF3Annotation gff3Annotation, int line) throws ValidationException {
+            description =
+                    "Check that a complement(...) wrapper in a transl_except attribute location agrees with the strand",
+            type = ValidationType.FEATURE,
+            severity = RuleSeverity.ERROR)
+    public void validateTranslExceptStrandConflict(GFF3Feature feature, int line) throws ValidationException {
 
-        Map<String, List<GFF3Feature>> grouped = gff3Annotation.getFeatures().stream()
-                .filter(f -> f.hasAttribute(TRANSL_EXCEPT))
-                .collect(Collectors.groupingBy(feature -> feature.getId().orElse(feature.hashCodeString())));
+        /** a "-" strand feature row can have a complement but does not have to,
+         *  normalised in {@link uk.ac.ebi.embl.gff3tools.validation.fix.TranslExceptComplementFix} **/
+        if (feature.isComplement()) {
+            return;
+        }
 
-        for (List<GFF3Feature> fragments : grouped.values()) {
+        for (String value : feature.getAttributeList(TRANSL_EXCEPT).orElse(List.of())) {
 
-            List<String> values = fragments.stream()
-                    .flatMap(f -> f.getAttributeList(TRANSL_EXCEPT).orElse(List.of()).stream())
-                    .distinct()
-                    .toList();
+            if (value == null || !POS_COMPLEMENT_PATTERN.matcher(value).find()) {
+                continue;
+            }
 
-            for (String value : values) {
-                if (value == null || !POS_COMPLEMENT_PATTERN.matcher(value).find()) {
-                    continue;
-                }
+            TranslExceptAttribute attribute;
+            try {
+                attribute = new TranslExceptAttribute(value);
+            } catch (TranslationException e) {
+                // Malformed values are already reported by {@link TRANSL_EXCEPT_LOCATION}.
+                continue;
+            }
 
-                TranslExceptAttribute attribute;
-                try {
-                    attribute = new TranslExceptAttribute(value);
-                } catch (TranslationException e) {
-                    // Malformed values are already reported by TRANSL_EXCEPT_LOCATION.
-                    continue;
-                }
-
-                final long start = attribute.getStartPosition();
-                final long end = attribute.getEndPosition();
-
-                List<GFF3Feature> containing = fragments.stream()
-                        .filter(f -> start >= f.getStart() && end <= f.getEnd())
-                        .toList();
-
-                if (containing.isEmpty()) {
-                    throw new ValidationException(line, COMPLEMENT_UNRESOLVED.formatted(TRANSL_EXCEPT, value));
-                }
-
-                Optional<GFF3Feature> conflicting =
-                        containing.stream().filter(f -> !f.isComplement()).findFirst();
-
-                if (conflicting.isPresent()) {
-                    throw new ValidationException(
-                            line,
-                            COMPLEMENT_STRAND_CONFLICT.formatted(
-                                    TRANSL_EXCEPT, conflicting.get().getStrand(), value));
-                }
+            // A join is written as several rows sharing an ID, and the same attribute value is
+            // copied onto every one of them. Only the row that actually spans the position owns
+            // that value, so without this check a mixed-strand join would be rejected because of a
+            // copy sitting on a row the position has nothing to do with.
+            //
+            // TRANSL_EXCEPT_LOCATION does not cover this: it asks whether *any* row of the group
+            // spans the position, which stays true for all of them.
+            if (attribute.getStartPosition() >= feature.getStart() && attribute.getEndPosition() <= feature.getEnd()) {
+                throw new ValidationException(
+                        line, COMPLEMENT_STRAND_CONFLICT.formatted(TRANSL_EXCEPT, feature.getStrand(), value));
             }
         }
     }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/AttributesLocationValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/AttributesLocationValidation.java
@@ -13,6 +13,7 @@ package uk.ac.ebi.embl.gff3tools.validation.builtin;
 import static uk.ac.ebi.embl.gff3tools.gff3.GFF3Attributes.*;
 
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import uk.ac.ebi.embl.gff3tools.exception.ValidationException;
 import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
@@ -22,6 +23,7 @@ import uk.ac.ebi.embl.gff3tools.translation.except.AminoAcidExcept;
 import uk.ac.ebi.embl.gff3tools.translation.except.AntiCodonAttribute;
 import uk.ac.ebi.embl.gff3tools.translation.except.TranslExceptAttribute;
 import uk.ac.ebi.embl.gff3tools.validation.meta.Gff3Validation;
+import uk.ac.ebi.embl.gff3tools.validation.meta.RuleSeverity;
 import uk.ac.ebi.embl.gff3tools.validation.meta.Validation;
 import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationMethod;
 import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationType;
@@ -34,6 +36,14 @@ public class AttributesLocationValidation implements Validation {
     private static final String INVALID_LOCATION_VALUE =
             "Invalid %s location: start must be > 0 and less than end at %s..%s";
     private static final String INVALID_LOCATION_SPAN = "%s location span must be \"%s\" at location %s";
+    private static final String COMPLEMENT_STRAND_CONFLICT =
+            "%s location is wrapped in complement() but the containing feature is on strand \"%s\": %s";
+    private static final String COMPLEMENT_UNRESOLVED =
+            "%s location is wrapped in complement() but does not fall within any feature fragment: %s";
+
+    /** Detects a {@code complement(...)} wrapper that survived {@code TRANSL_EXCEPT_COMPLEMENT}. */
+    private static final Pattern POS_COMPLEMENT_PATTERN =
+            Pattern.compile("\\(\\s*pos\\s*:\\s*complement\\(", Pattern.CASE_INSENSITIVE);
 
     @ValidationMethod(rule = "ANTI_CODON_LOCATION", type = ValidationType.ANNOTATION)
     public void validateAntiCodon(GFF3Annotation gff3Annotation, int line) throws ValidationException {
@@ -51,6 +61,77 @@ public class AttributesLocationValidation implements Validation {
                 .collect(Collectors.groupingBy(feature -> feature.getId().orElse(feature.hashCodeString())));
 
         validateCodonAttribute(grouped, TRANSL_EXCEPT, line);
+    }
+
+    /**
+     * Reports a {@code complement(...)} wrapper that {@code TRANSL_EXCEPT_COMPLEMENT} refused to
+     * strip, i.e. one whose direction cannot be shown to agree with the feature's strand.
+     *
+     * <p>The wrapper duplicates information already held in column 7, so it is safe to remove only
+     * when the two agree. When they disagree the fix deliberately leaves the value alone rather
+     * than resolving the conflict in favour of the strand column, and this rule surfaces it — a
+     * silent strip would launder a genuine annotation error into clean-looking data.
+     *
+     * <p>Defaults to {@link RuleSeverity#WARN}: sequencetools strips the wrapper silently and
+     * flags nothing, so raising an error here would reject files ENA itself accepts. Curators can
+     * opt into strictness with {@code --rules TRANSL_EXCEPT_STRAND_CONFLICT:ERROR}.
+     *
+     * <p>There is deliberately no {@code anticodon} counterpart: there the complement flag is
+     * consumed by sequencetools to re-extract the {@code seq:} payload, so it is meaningful rather
+     * than redundant and is never stripped in the first place.
+     */
+    @ValidationMethod(
+            rule = "TRANSL_EXCEPT_STRAND_CONFLICT",
+            type = ValidationType.ANNOTATION,
+            severity = RuleSeverity.WARN)
+    public void validateTranslExceptStrandConflict(GFF3Annotation gff3Annotation, int line) throws ValidationException {
+
+        Map<String, List<GFF3Feature>> grouped = gff3Annotation.getFeatures().stream()
+                .filter(f -> f.hasAttribute(TRANSL_EXCEPT))
+                .collect(Collectors.groupingBy(feature -> feature.getId().orElse(feature.hashCodeString())));
+
+        for (List<GFF3Feature> fragments : grouped.values()) {
+
+            List<String> values = fragments.stream()
+                    .flatMap(f -> f.getAttributeList(TRANSL_EXCEPT).orElse(List.of()).stream())
+                    .distinct()
+                    .toList();
+
+            for (String value : values) {
+                if (value == null || !POS_COMPLEMENT_PATTERN.matcher(value).find()) {
+                    continue;
+                }
+
+                TranslExceptAttribute attribute;
+                try {
+                    attribute = new TranslExceptAttribute(value);
+                } catch (TranslationException e) {
+                    // Malformed values are already reported by TRANSL_EXCEPT_LOCATION.
+                    continue;
+                }
+
+                final long start = attribute.getStartPosition();
+                final long end = attribute.getEndPosition();
+
+                List<GFF3Feature> containing = fragments.stream()
+                        .filter(f -> start >= f.getStart() && end <= f.getEnd())
+                        .toList();
+
+                if (containing.isEmpty()) {
+                    throw new ValidationException(line, COMPLEMENT_UNRESOLVED.formatted(TRANSL_EXCEPT, value));
+                }
+
+                Optional<GFF3Feature> conflicting =
+                        containing.stream().filter(f -> !f.isComplement()).findFirst();
+
+                if (conflicting.isPresent()) {
+                    throw new ValidationException(
+                            line,
+                            COMPLEMENT_STRAND_CONFLICT.formatted(
+                                    TRANSL_EXCEPT, conflicting.get().getStrand(), value));
+                }
+            }
+        }
     }
 
     private void validateCodonAttribute(Map<String, List<GFF3Feature>> groupedFeatures, String attribute, int line)

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/AttributesLocationValidation.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/builtin/AttributesLocationValidation.java
@@ -64,21 +64,10 @@ public class AttributesLocationValidation implements Validation {
     }
 
     /**
-     * Reports a {@code complement(...)} wrapper that {@code TRANSL_EXCEPT_COMPLEMENT} refused to
-     * strip, i.e. one whose direction cannot be shown to agree with the feature's strand.
-     *
-     * <p>The wrapper duplicates information already held in column 7, so it is safe to remove only
-     * when the two agree. When they disagree the fix deliberately leaves the value alone rather
-     * than resolving the conflict in favour of the strand column, and this rule surfaces it — a
-     * silent strip would launder a genuine annotation error into clean-looking data.
-     *
-     * <p>Defaults to {@link RuleSeverity#WARN}: sequencetools strips the wrapper silently and
-     * flags nothing, so raising an error here would reject files ENA itself accepts. Curators can
-     * opt into strictness with {@code --rules TRANSL_EXCEPT_STRAND_CONFLICT:ERROR}.
-     *
-     * <p>There is deliberately no {@code anticodon} counterpart: there the complement flag is
-     * consumed by sequencetools to re-extract the {@code seq:} payload, so it is meaningful rather
-     * than redundant and is never stripped in the first place.
+     * Reports a {@code complement(...)} wrapper in a {@code transl_except} value whose direction the
+     * row's strand column does not confirm. {@code TRANSL_EXCEPT_COMPLEMENT} removes the wrapper
+     * when the two agree; when they disagree one of them is wrong, so this reports it rather than
+     * letting either side silently win.
      */
     @ValidationMethod(
             rule = "TRANSL_EXCEPT_STRAND_CONFLICT",

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFix.java
@@ -26,23 +26,16 @@ import uk.ac.ebi.embl.gff3tools.validation.meta.Gff3Fix;
 import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationPriority;
 
 /**
- * Removes a redundant {@code complement(...)} wrapper from the {@code pos:} location of
- * {@code transl_except}. This is the GFF3 counterpart of sequencetools'
- * {@code Transl_exceptLocationFix} ("Invalid Location:Complement ignored in transl_except").
+ * Removes a redundant {@code complement(...)} wrapper from a {@code transl_except} location, as
+ * sequencetools' {@code Transl_exceptLocationFix} does for flat files.
  *
- * <p>In GFF3 the reading direction lives in column 7, and {@code Translator} derives it solely
- * from there — the wrapper only duplicates that, and the numeric range is identical either way.
- * The wrapper is therefore stripped <strong>only where the duplication is provable</strong>:
- * every fragment that contains the codon must be on the minus strand. A plus strand, an unknown
- * strand ({@code .}/{@code ?}), or a codon that resolves to no fragment is left untouched, so a
- * genuine contradiction is never silently resolved — {@code TRANSL_EXCEPT_STRAND_CONFLICT}
- * reports those instead.
+ * Direction lives in column 7, so the wrapper duplicates it — but it is stripped only where that is
+ * provable: every fragment containing the codon is on the minus strand. Anything else is left for
+ * {@code TRANSL_EXCEPT_STRAND_CONFLICT} to report.
  *
- * <p><strong>{@code anticodon} is deliberately not handled.</strong> sequencetools'
- * {@code AnticodonQualifierFix} re-extracts the {@code seq:} payload via {@code SegmentFactory}
- * using the anticodon location's own complement flag, so stripping it there would make the value
- * internally false. {@code transl_except} carries no such direction-dependent payload: its
- * {@code aa:} is stated outright by the submitter, never computed from the sequence.
+ * <p><strong>{@code anticodon} is deliberately excluded:</strong> sequencetools re-extracts its
+ * {@code seq:} payload using that location's own complement flag, so stripping it there would make
+ * the value internally false.
  */
 @Slf4j
 @Gff3Fix(
@@ -52,16 +45,8 @@ public class TranslExceptComplementFix implements Fix {
 
     private static final String MINUS_STRAND = "-";
 
-    /**
-     * Anchored so that only a simple range is ever rewritten. Compound bodies
-     * ({@code join}/{@code order}), fuzzy bounds ({@code <100}) and remote accessions
-     * ({@code X12345.1:100..102}) all fail to match and are left for validation to judge.
-     *
-     * <p>Group 1 is everything up to the wrapper, group 2 the range, group 3 the remainder, so
-     * recomposing {@code 1 + 2 + 3} preserves the original spacing, case and {@code aa:} token
-     * exactly. In particular the amino acid is never canonicalised — that is orientation-unrelated
-     * scope creep which sequencetools happens to also perform.
-     */
+    // Anchored to a simple range, so join/order, fuzzy bounds and remote accessions never match.
+    // Recomposing groups 1+2+3 drops the wrapper and preserves spacing, case and the aa: token.
     private static final Pattern POS_COMPLEMENT_PATTERN = Pattern.compile(
             "^(\\s*\\(\\s*pos\\s*:\\s*)complement\\(\\s*(\\d+(?:\\s*\\.\\.\\s*\\d+)?)\\s*\\)(\\s*,\\s*aa\\s*:\\s*[^\\s,)]+\\s*\\)\\s*)$",
             Pattern.CASE_INSENSITIVE);
@@ -80,9 +65,7 @@ public class TranslExceptComplementFix implements Fix {
                 .collect(Collectors.groupingBy(feature -> feature.getId().orElse(feature.hashCodeString())));
 
         for (List<GFF3Feature> fragments : grouped.values()) {
-            // A fix must never propagate an exception: executeFixes passes a null severity to
-            // handleRuleException, which turns any escape into a hard error that --rules cannot
-            // suppress. Skip the offending group instead.
+            // Must never propagate: executeFixes turns an escape into an unsuppressable error.
             try {
                 fixGroup(fragments, line);
             } catch (RuntimeException e) {
@@ -92,10 +75,9 @@ public class TranslExceptComplementFix implements Fix {
     }
 
     /**
-     * Decides once per distinct value, using the whole ID-group, so that every row of a join ends
-     * up with identical text. {@code GFF3AnnotationFactory} replicates the attribute onto each
-     * location row, and {@code GFF3Mapper} keeps only the first row's attributes when merging a
-     * join back to flat file — so a per-row decision would be silently order-dependent.
+     * Decides once per distinct value across the whole ID-group, so every row of a join ends up
+     * identical — GFF3Mapper keeps only the first row's attributes when merging a join back to flat
+     * file, making a per-row decision order-dependent.
      */
     private void fixGroup(List<GFF3Feature> fragments, int line) {
 
@@ -123,9 +105,7 @@ public class TranslExceptComplementFix implements Fix {
         }
     }
 
-    /**
-     * @return the normalised value, or {@code null} when the wrapper must be preserved.
-     */
+    /** @return the normalised value, or {@code null} to leave it untouched. */
     private String stripIfRedundant(String value, List<GFF3Feature> fragments) {
 
         Matcher matcher = POS_COMPLEMENT_PATTERN.matcher(value);
@@ -144,7 +124,6 @@ public class TranslExceptComplementFix implements Fix {
             start = Long.parseLong(range.group(1));
             end = range.group(2) != null ? Long.parseLong(range.group(2)) : start;
         } catch (NumberFormatException e) {
-            // Out-of-range digits: leave the value for TRANSL_EXCEPT_LOCATION to judge.
             return null;
         }
 
@@ -156,10 +135,8 @@ public class TranslExceptComplementFix implements Fix {
     }
 
     /**
-     * The wrapper is redundant only when every fragment actually containing the codon is on the
-     * minus strand. Testing containment rather than "the whole group is minus" keeps a legitimate
-     * mixed-strand (trans-spliced) join fixable when the codon sits in its minus-strand segment,
-     * while still refusing when the codon sits in a plus-strand segment.
+     * Containment rather than "whole group is minus" keeps a mixed-strand trans-spliced join
+     * fixable when the codon sits in its minus segment.
      */
     private boolean isRedundantWithStrand(List<GFF3Feature> fragments, long start, long end) {
 

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFix.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.validation.fix;
+
+import static uk.ac.ebi.embl.gff3tools.gff3.GFF3Attributes.TRANSL_EXCEPT;
+import static uk.ac.ebi.embl.gff3tools.validation.meta.ValidationType.ANNOTATION;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Feature;
+import uk.ac.ebi.embl.gff3tools.validation.meta.Fix;
+import uk.ac.ebi.embl.gff3tools.validation.meta.FixMethod;
+import uk.ac.ebi.embl.gff3tools.validation.meta.Gff3Fix;
+import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationPriority;
+
+/**
+ * Removes a redundant {@code complement(...)} wrapper from the {@code pos:} location of
+ * {@code transl_except}. This is the GFF3 counterpart of sequencetools'
+ * {@code Transl_exceptLocationFix} ("Invalid Location:Complement ignored in transl_except").
+ *
+ * <p>In GFF3 the reading direction lives in column 7, and {@code Translator} derives it solely
+ * from there — the wrapper only duplicates that, and the numeric range is identical either way.
+ * The wrapper is therefore stripped <strong>only where the duplication is provable</strong>:
+ * every fragment that contains the codon must be on the minus strand. A plus strand, an unknown
+ * strand ({@code .}/{@code ?}), or a codon that resolves to no fragment is left untouched, so a
+ * genuine contradiction is never silently resolved — {@code TRANSL_EXCEPT_STRAND_CONFLICT}
+ * reports those instead.
+ *
+ * <p><strong>{@code anticodon} is deliberately not handled.</strong> sequencetools'
+ * {@code AnticodonQualifierFix} re-extracts the {@code seq:} payload via {@code SegmentFactory}
+ * using the anticodon location's own complement flag, so stripping it there would make the value
+ * internally false. {@code transl_except} carries no such direction-dependent payload: its
+ * {@code aa:} is stated outright by the submitter, never computed from the sequence.
+ */
+@Slf4j
+@Gff3Fix(
+        name = "TRANSL_EXCEPT_COMPLEMENT",
+        description = "Remove the redundant complement(...) wrapper from transl_except locations")
+public class TranslExceptComplementFix implements Fix {
+
+    private static final String MINUS_STRAND = "-";
+
+    /**
+     * Anchored so that only a simple range is ever rewritten. Compound bodies
+     * ({@code join}/{@code order}), fuzzy bounds ({@code <100}) and remote accessions
+     * ({@code X12345.1:100..102}) all fail to match and are left for validation to judge.
+     *
+     * <p>Group 1 is everything up to the wrapper, group 2 the range, group 3 the remainder, so
+     * recomposing {@code 1 + 2 + 3} preserves the original spacing, case and {@code aa:} token
+     * exactly. In particular the amino acid is never canonicalised — that is orientation-unrelated
+     * scope creep which sequencetools happens to also perform.
+     */
+    private static final Pattern POS_COMPLEMENT_PATTERN = Pattern.compile(
+            "^(\\s*\\(\\s*pos\\s*:\\s*)complement\\(\\s*(\\d+(?:\\s*\\.\\.\\s*\\d+)?)\\s*\\)(\\s*,\\s*aa\\s*:\\s*[^\\s,)]+\\s*\\)\\s*)$",
+            Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern RANGE_PATTERN = Pattern.compile("^(\\d+)(?:\\s*\\.\\.\\s*(\\d+))?$");
+
+    @FixMethod(
+            rule = "TRANSL_EXCEPT_COMPLEMENT",
+            description = "Strip complement(...) from transl_except locations on minus-strand features",
+            type = ANNOTATION,
+            priority = ValidationPriority.HIGH)
+    public void fixAnnotation(GFF3Annotation annotation, int line) {
+
+        Map<String, List<GFF3Feature>> grouped = annotation.getFeatures().stream()
+                .filter(feature -> feature.hasAttribute(TRANSL_EXCEPT))
+                .collect(Collectors.groupingBy(feature -> feature.getId().orElse(feature.hashCodeString())));
+
+        for (List<GFF3Feature> fragments : grouped.values()) {
+            // A fix must never propagate an exception: executeFixes passes a null severity to
+            // handleRuleException, which turns any escape into a hard error that --rules cannot
+            // suppress. Skip the offending group instead.
+            try {
+                fixGroup(fragments, line);
+            } catch (RuntimeException e) {
+                log.warn("TRANSL_EXCEPT_COMPLEMENT: skipping feature group at line {}: {}", line, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Decides once per distinct value, using the whole ID-group, so that every row of a join ends
+     * up with identical text. {@code GFF3AnnotationFactory} replicates the attribute onto each
+     * location row, and {@code GFF3Mapper} keeps only the first row's attributes when merging a
+     * join back to flat file — so a per-row decision would be silently order-dependent.
+     */
+    private void fixGroup(List<GFF3Feature> fragments, int line) {
+
+        Map<String, String> rewrites = new LinkedHashMap<>();
+        Set<String> evaluated = new HashSet<>();
+
+        for (GFF3Feature fragment : fragments) {
+            for (String value : fragment.getAttributeList(TRANSL_EXCEPT).orElse(List.of())) {
+                if (value == null || !evaluated.add(value)) {
+                    continue;
+                }
+                String stripped = stripIfRedundant(value, fragments);
+                if (stripped != null) {
+                    rewrites.put(value, stripped);
+                }
+            }
+        }
+
+        if (rewrites.isEmpty()) {
+            return;
+        }
+
+        for (GFF3Feature fragment : fragments) {
+            applyRewrites(fragment, rewrites, line);
+        }
+    }
+
+    /**
+     * @return the normalised value, or {@code null} when the wrapper must be preserved.
+     */
+    private String stripIfRedundant(String value, List<GFF3Feature> fragments) {
+
+        Matcher matcher = POS_COMPLEMENT_PATTERN.matcher(value);
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        Matcher range = RANGE_PATTERN.matcher(matcher.group(2));
+        if (!range.matches()) {
+            return null;
+        }
+
+        long start;
+        long end;
+        try {
+            start = Long.parseLong(range.group(1));
+            end = range.group(2) != null ? Long.parseLong(range.group(2)) : start;
+        } catch (NumberFormatException e) {
+            // Out-of-range digits: leave the value for TRANSL_EXCEPT_LOCATION to judge.
+            return null;
+        }
+
+        if (!isRedundantWithStrand(fragments, start, end)) {
+            return null;
+        }
+
+        return matcher.group(1) + matcher.group(2) + matcher.group(3);
+    }
+
+    /**
+     * The wrapper is redundant only when every fragment actually containing the codon is on the
+     * minus strand. Testing containment rather than "the whole group is minus" keeps a legitimate
+     * mixed-strand (trans-spliced) join fixable when the codon sits in its minus-strand segment,
+     * while still refusing when the codon sits in a plus-strand segment.
+     */
+    private boolean isRedundantWithStrand(List<GFF3Feature> fragments, long start, long end) {
+
+        List<GFF3Feature> containing = fragments.stream()
+                .filter(fragment -> start >= fragment.getStart() && end <= fragment.getEnd())
+                .toList();
+
+        return !containing.isEmpty()
+                && containing.stream().allMatch(fragment -> MINUS_STRAND.equals(fragment.getStrand()));
+    }
+
+    private void applyRewrites(GFF3Feature feature, Map<String, String> rewrites, int line) {
+
+        List<String> values = feature.getAttributeList(TRANSL_EXCEPT).orElse(null);
+        if (values == null || values.isEmpty()) {
+            return;
+        }
+
+        List<String> updated = new ArrayList<>(values.size());
+        boolean changed = false;
+
+        for (String value : values) {
+            String rewritten = rewrites.get(value);
+            if (rewritten == null) {
+                updated.add(value);
+                continue;
+            }
+            changed = true;
+            updated.add(rewritten);
+            log.info(
+                    "Fix: removed redundant complement() from {} on '{}' at line {}: '{}' -> '{}'",
+                    TRANSL_EXCEPT,
+                    feature.accession(),
+                    line,
+                    value,
+                    rewritten);
+        }
+
+        if (changed) {
+            feature.setAttributeList(TRANSL_EXCEPT, updated);
+        }
+    }
+}

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFix.java
@@ -26,8 +26,8 @@ import uk.ac.ebi.embl.gff3tools.validation.meta.Gff3Fix;
 import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationPriority;
 
 /**
- * Removes a redundant {@code complement(...)} wrapper from a {@code transl_except} location, as
- * sequencetools' {@code Transl_exceptLocationFix} does for flat files.
+ * Removes a redundant {@code complement(...)} wrapper from a {@code transl_except} location,
+ * in case it is left-over from FF->GFF3 conversion.
  *
  * Direction lives in column 7, so the wrapper duplicates it — but it is stripped only where that is
  * provable: every fragment containing the codon is on the minus strand. Anything else is left for
@@ -43,15 +43,13 @@ import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationPriority;
         description = "Remove the redundant complement(...) wrapper from transl_except locations")
 public class TranslExceptComplementFix implements Fix {
 
-    private static final String MINUS_STRAND = "-";
-
     // Anchored to a simple range, so join/order, fuzzy bounds and remote accessions never match.
-    // Recomposing groups 1+2+3 drops the wrapper and preserves spacing, case and the aa: token.
+    // Rebuilding prefix + range + suffix drops the wrapper and preserves spacing, case and aa:.
     private static final Pattern POS_COMPLEMENT_PATTERN = Pattern.compile(
-            "^(\\s*\\(\\s*pos\\s*:\\s*)complement\\(\\s*(\\d+(?:\\s*\\.\\.\\s*\\d+)?)\\s*\\)(\\s*,\\s*aa\\s*:\\s*[^\\s,)]+\\s*\\)\\s*)$",
+            "^(?<prefix>\\s*\\(\\s*pos\\s*:\\s*)"
+                    + "complement\\(\\s*(?<range>(?<start>\\d+)(?:\\s*\\.\\.\\s*(?<end>\\d+))?)\\s*\\)"
+                    + "(?<suffix>\\s*,\\s*aa\\s*:\\s*[^\\s,)]+\\s*\\)\\s*)$",
             Pattern.CASE_INSENSITIVE);
-
-    private static final Pattern RANGE_PATTERN = Pattern.compile("^(\\d+)(?:\\s*\\.\\.\\s*(\\d+))?$");
 
     @FixMethod(
             rule = "TRANSL_EXCEPT_COMPLEMENT",
@@ -60,18 +58,11 @@ public class TranslExceptComplementFix implements Fix {
             priority = ValidationPriority.HIGH)
     public void fixAnnotation(GFF3Annotation annotation, int line) {
 
-        Map<String, List<GFF3Feature>> grouped = annotation.getFeatures().stream()
+        Map<String, List<GFF3Feature>> featuresWithAttribute = annotation.getFeatures().stream()
                 .filter(feature -> feature.hasAttribute(TRANSL_EXCEPT))
                 .collect(Collectors.groupingBy(feature -> feature.getId().orElse(feature.hashCodeString())));
 
-        for (List<GFF3Feature> fragments : grouped.values()) {
-            // Must never propagate: executeFixes turns an escape into an unsuppressable error.
-            try {
-                fixGroup(fragments, line);
-            } catch (RuntimeException e) {
-                log.warn("TRANSL_EXCEPT_COMPLEMENT: skipping feature group at line {}: {}", line, e.getMessage());
-            }
-        }
+        featuresWithAttribute.values().forEach(featureGroup -> fixGroup(featureGroup, line));
     }
 
     /**
@@ -81,28 +72,29 @@ public class TranslExceptComplementFix implements Fix {
      */
     private void fixGroup(List<GFF3Feature> fragments, int line) {
 
+        List<String> distinctValues = fragments.stream()
+                .flatMap(fragment -> fragment.getAttributeList(TRANSL_EXCEPT).orElse(List.of()).stream())
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
         Map<String, String> rewrites = new LinkedHashMap<>();
-        Set<String> evaluated = new HashSet<>();
-
-        for (GFF3Feature fragment : fragments) {
-            for (String value : fragment.getAttributeList(TRANSL_EXCEPT).orElse(List.of())) {
-                if (value == null || !evaluated.add(value)) {
-                    continue;
-                }
-                String stripped = stripIfRedundant(value, fragments);
-                if (stripped != null) {
-                    rewrites.put(value, stripped);
-                }
+        for (String value : distinctValues) {
+            String stripped = stripIfRedundant(value, fragments);
+            if (stripped == null) {
+                continue;
             }
+            rewrites.put(value, stripped);
+            log.info(
+                    "Fix: removed redundant complement() from {} on '{}' at line {}: '{}' -> '{}'",
+                    TRANSL_EXCEPT,
+                    fragments.get(0).accession(),
+                    line,
+                    value,
+                    stripped);
         }
 
-        if (rewrites.isEmpty()) {
-            return;
-        }
-
-        for (GFF3Feature fragment : fragments) {
-            applyRewrites(fragment, rewrites, line);
-        }
+        fragments.forEach(fragment -> applyRewrites(fragment, rewrites));
     }
 
     /** @return the normalised value, or {@code null} to leave it untouched. */
@@ -113,16 +105,12 @@ public class TranslExceptComplementFix implements Fix {
             return null;
         }
 
-        Matcher range = RANGE_PATTERN.matcher(matcher.group(2));
-        if (!range.matches()) {
-            return null;
-        }
-
         long start;
         long end;
         try {
-            start = Long.parseLong(range.group(1));
-            end = range.group(2) != null ? Long.parseLong(range.group(2)) : start;
+            start = Long.parseLong(matcher.group("start"));
+            String endGroup = matcher.group("end");
+            end = endGroup != null ? Long.parseLong(endGroup) : start;
         } catch (NumberFormatException e) {
             return null;
         }
@@ -131,7 +119,7 @@ public class TranslExceptComplementFix implements Fix {
             return null;
         }
 
-        return matcher.group(1) + matcher.group(2) + matcher.group(3);
+        return matcher.group("prefix") + matcher.group("range") + matcher.group("suffix");
     }
 
     /**
@@ -144,39 +132,20 @@ public class TranslExceptComplementFix implements Fix {
                 .filter(fragment -> start >= fragment.getStart() && end <= fragment.getEnd())
                 .toList();
 
-        return !containing.isEmpty()
-                && containing.stream().allMatch(fragment -> MINUS_STRAND.equals(fragment.getStrand()));
+        return !containing.isEmpty() && containing.stream().allMatch(GFF3Feature::isComplement);
     }
 
-    private void applyRewrites(GFF3Feature feature, Map<String, String> rewrites, int line) {
+    private void applyRewrites(GFF3Feature feature, Map<String, String> rewrites) {
 
-        List<String> values = feature.getAttributeList(TRANSL_EXCEPT).orElse(null);
-        if (values == null || values.isEmpty()) {
+        List<String> values = feature.getAttributeList(TRANSL_EXCEPT).orElse(List.of());
+        if (values.stream().noneMatch(rewrites::containsKey)) {
             return;
         }
 
-        List<String> updated = new ArrayList<>(values.size());
-        boolean changed = false;
+        List<String> updated = values.stream()
+                .map(value -> rewrites.getOrDefault(value, value))
+                .toList();
 
-        for (String value : values) {
-            String rewritten = rewrites.get(value);
-            if (rewritten == null) {
-                updated.add(value);
-                continue;
-            }
-            changed = true;
-            updated.add(rewritten);
-            log.info(
-                    "Fix: removed redundant complement() from {} on '{}' at line {}: '{}' -> '{}'",
-                    TRANSL_EXCEPT,
-                    feature.accession(),
-                    line,
-                    value,
-                    rewritten);
-        }
-
-        if (changed) {
-            feature.setAttributeList(TRANSL_EXCEPT, updated);
-        }
+        feature.setAttributeList(TRANSL_EXCEPT, new ArrayList<>(updated));
     }
 }

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFix.java
@@ -23,24 +23,7 @@ import uk.ac.ebi.embl.gff3tools.gff3.GFF3Feature;
 import uk.ac.ebi.embl.gff3tools.validation.meta.Fix;
 import uk.ac.ebi.embl.gff3tools.validation.meta.FixMethod;
 import uk.ac.ebi.embl.gff3tools.validation.meta.Gff3Fix;
-import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationPriority;
 
-/**
- * Rewrites {@code transl_except} attribute values to drop a {@code complement(...)} wrapper around
- * the position, so {@code (pos:complement(4370..4372),aa:Sec)} becomes {@code (pos:4370..4372,aa:Sec)}.
- * That wrapper is flat-file syntax meaning "read backwards" and survives FF-&gt;GFF3 conversion, but
- * GFF3 already states direction in the strand column, so it is duplicated information — the numbers
- * are identical either way.
- *
- * <p>It is dropped only when the strand column agrees, i.e. holds the literal {@code "-"}.
- * Otherwise the two contradict each other, so the value is left
- * untouched and {@code TRANSL_EXCEPT_STRAND_CONFLICT} reports it rather than this fix silently
- * picking a winner.
- *
- * <p>The lookalike {@code anticodon} attribute is deliberately left alone: it carries an extra
- * {@code seq:} part that other EBI tooling recomputes from that same wrapper, so removing it there
- * would change what the value claims.
- */
 @Slf4j
 @Gff3Fix(
         name = "TRANSL_EXCEPT_COMPLEMENT",
@@ -60,8 +43,7 @@ public class TranslExceptComplementFix implements Fix {
     @FixMethod(
             rule = "TRANSL_EXCEPT_COMPLEMENT",
             description = "Strip complement(...) from transl_except locations on minus-strand features",
-            type = ANNOTATION,
-            priority = ValidationPriority.HIGH)
+            type = ANNOTATION)
     public void fixAnnotation(GFF3Annotation annotation, int line) {
 
         Map<String, List<GFF3Feature>> featuresWithAttribute = annotation.getFeatures().stream()

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFix.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFix.java
@@ -26,16 +26,20 @@ import uk.ac.ebi.embl.gff3tools.validation.meta.Gff3Fix;
 import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationPriority;
 
 /**
- * Removes a redundant {@code complement(...)} wrapper from a {@code transl_except} location,
- * in case it is left-over from FF->GFF3 conversion.
+ * Rewrites {@code transl_except} attribute values to drop a {@code complement(...)} wrapper around
+ * the position, so {@code (pos:complement(4370..4372),aa:Sec)} becomes {@code (pos:4370..4372,aa:Sec)}.
+ * That wrapper is flat-file syntax meaning "read backwards" and survives FF-&gt;GFF3 conversion, but
+ * GFF3 already states direction in the strand column, so it is duplicated information — the numbers
+ * are identical either way.
  *
- * Direction lives in column 7, so the wrapper duplicates it — but it is stripped only where that is
- * provable: every fragment containing the codon is on the minus strand. Anything else is left for
- * {@code TRANSL_EXCEPT_STRAND_CONFLICT} to report.
+ * <p>It is dropped only when the strand column agrees, i.e. holds the literal {@code "-"}.
+ * Otherwise the two contradict each other, so the value is left
+ * untouched and {@code TRANSL_EXCEPT_STRAND_CONFLICT} reports it rather than this fix silently
+ * picking a winner.
  *
- * <p><strong>{@code anticodon} is deliberately excluded:</strong> sequencetools re-extracts its
- * {@code seq:} payload using that location's own complement flag, so stripping it there would make
- * the value internally false.
+ * <p>The lookalike {@code anticodon} attribute is deliberately left alone: it carries an extra
+ * {@code seq:} part that other EBI tooling recomputes from that same wrapper, so removing it there
+ * would change what the value claims.
  */
 @Slf4j
 @Gff3Fix(
@@ -43,8 +47,10 @@ import uk.ac.ebi.embl.gff3tools.validation.meta.ValidationPriority;
         description = "Remove the redundant complement(...) wrapper from transl_except locations")
 public class TranslExceptComplementFix implements Fix {
 
-    // Anchored to a simple range, so join/order, fuzzy bounds and remote accessions never match.
-    // Rebuilding prefix + range + suffix drops the wrapper and preserves spacing, case and aa:.
+    // Deliberately matches only a plain "123" or "123..456" inside complement(...); anything more
+    // exotic (join(...), <100, OTHER_ACC:100..102) is left untouched for validation to judge.
+    // The named groups let the value be rebuilt as prefix + range + suffix, which removes the
+    // wrapper while keeping the original spacing and casing byte for byte.
     private static final Pattern POS_COMPLEMENT_PATTERN = Pattern.compile(
             "^(?<prefix>\\s*\\(\\s*pos\\s*:\\s*)"
                     + "complement\\(\\s*(?<range>(?<start>\\d+)(?:\\s*\\.\\.\\s*(?<end>\\d+))?)\\s*\\)"
@@ -66,9 +72,10 @@ public class TranslExceptComplementFix implements Fix {
     }
 
     /**
-     * Decides once per distinct value across the whole ID-group, so every row of a join ends up
-     * identical — GFF3Mapper keeps only the first row's attributes when merging a join back to flat
-     * file, making a per-row decision order-dependent.
+     * One feature can span several GFF3 rows sharing an {@code ID} (the fragments of a join), and
+     * each row carries its own copy of the same attribute value. Decide once for the whole group so
+     * every row ends up with identical text — {@code GFF3Mapper} keeps only the first row's
+     * attributes when converting back to flat file, so a per-row decision would depend on row order.
      */
     private void fixGroup(List<GFF3Feature> fragments, int line) {
 
@@ -123,8 +130,9 @@ public class TranslExceptComplementFix implements Fix {
     }
 
     /**
-     * Containment rather than "whole group is minus" keeps a mixed-strand trans-spliced join
-     * fixable when the codon sits in its minus segment.
+     * Only the rows whose own start/end span the position get a say on the strand. Checking those
+     * rather than the whole group matters because the rows of one feature may legitimately carry
+     * different strands.
      */
     private boolean isRedundantWithStrand(List<GFF3Feature> fragments, long start, long end) {
 

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/AttributesLocationValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/AttributesLocationValidationTest.java
@@ -320,7 +320,7 @@ public class AttributesLocationValidationTest {
         gff3Annotation.addFeature(f1);
         gff3Annotation.addFeature(f2);
 
-        Assertions.assertDoesNotThrow(() -> attributesLocationValidation.validateAntiCodon(gff3Annotation, 1));
+        Assertions.assertDoesNotThrow(() -> attributesLocationValidation.validateTranslExcept(gff3Annotation, 1));
     }
 
     @Test
@@ -540,7 +540,7 @@ public class AttributesLocationValidationTest {
         gff3Annotation.addFeature(f1);
         gff3Annotation.addFeature(f2);
 
-        Assertions.assertDoesNotThrow(() -> attributesLocationValidation.validateAntiCodon(gff3Annotation, 1));
+        Assertions.assertDoesNotThrow(() -> attributesLocationValidation.validateTranslExcept(gff3Annotation, 1));
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/AttributesLocationValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/AttributesLocationValidationTest.java
@@ -601,12 +601,11 @@ public class AttributesLocationValidationTest {
     @Test
     public void testStrandConflictReportedWhenComplementSitsOnPlusStrand() {
         String value = "(pos:complement(4370..4372),aa:Sec)";
-        gff3Annotation.addFeature(
-                featureOnStrand("c1", OntologyTerm.CDS.name(), 4000, 5000, "+", TRANSL_EXCEPT, value));
+        GFF3Feature cds = featureOnStrand("c1", OntologyTerm.CDS.name(), 4000, 5000, "+", TRANSL_EXCEPT, value);
 
         ValidationException ex = Assertions.assertThrows(
                 ValidationException.class,
-                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
+                () -> attributesLocationValidation.validateTranslExceptStrandConflict(cds, 1));
 
         Assertions.assertTrue(ex.getMessage()
                 .contains("%s location is wrapped in complement() but the containing feature is on strand \"%s\": %s"
@@ -616,12 +615,11 @@ public class AttributesLocationValidationTest {
     @Test
     public void testStrandConflictReportedWhenStrandIsUnknown() {
         String value = "(pos:complement(4370..4372),aa:Sec)";
-        gff3Annotation.addFeature(
-                featureOnStrand("c1", OntologyTerm.CDS.name(), 4000, 5000, ".", TRANSL_EXCEPT, value));
+        GFF3Feature cds = featureOnStrand("c1", OntologyTerm.CDS.name(), 4000, 5000, ".", TRANSL_EXCEPT, value);
 
         ValidationException ex = Assertions.assertThrows(
                 ValidationException.class,
-                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
+                () -> attributesLocationValidation.validateTranslExceptStrandConflict(cds, 1));
 
         // A "." strand states no direction at all, so the wrapper cannot be confirmed and is
         // reported rather than quietly accepted.
@@ -629,61 +627,53 @@ public class AttributesLocationValidationTest {
     }
 
     @Test
-    public void testStrandConflictReportedWhenCodonMatchesNoFragment() {
-        String value = "(pos:complement(9000..9002),aa:Sec)";
-        gff3Annotation.addFeature(
-                featureOnStrand("c1", OntologyTerm.CDS.name(), 4000, 5000, "-", TRANSL_EXCEPT, value));
+    public void testNoStrandConflictWhenPositionIsOutsideTheRow() {
+        GFF3Feature cds = featureOnStrand(
+                "c1", OntologyTerm.CDS.name(), 4000, 5000, "+", TRANSL_EXCEPT, "(pos:complement(9000..9002),aa:Sec)");
 
-        ValidationException ex = Assertions.assertThrows(
-                ValidationException.class,
-                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
-
-        Assertions.assertTrue(ex.getMessage()
-                .contains("%s location is wrapped in complement() but does not fall within any feature fragment: %s"
-                        .formatted(TRANSL_EXCEPT, value)));
+        // A row can only speak for the positions it spans. Where no row spans the position,
+        // TRANSL_EXCEPT_LOCATION already rejects it as out of range.
+        Assertions.assertDoesNotThrow(() -> attributesLocationValidation.validateTranslExceptStrandConflict(cds, 1));
     }
 
     @Test
     public void testNoStrandConflictWhenComplementAgreesWithMinusStrand() {
-        gff3Annotation.addFeature(featureOnStrand(
-                "c1", OntologyTerm.CDS.name(), 4000, 5000, "-", TRANSL_EXCEPT, "(pos:complement(4370..4372),aa:Sec)"));
+        GFF3Feature cds = featureOnStrand(
+                "c1", OntologyTerm.CDS.name(), 4000, 5000, "-", TRANSL_EXCEPT, "(pos:complement(4370..4372),aa:Sec)");
 
         // Here the wrapper and the strand column agree, so there is nothing to report.
-        Assertions.assertDoesNotThrow(
-                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
+        Assertions.assertDoesNotThrow(() -> attributesLocationValidation.validateTranslExceptStrandConflict(cds, 1));
     }
 
     @Test
-    public void testNoStrandConflictWhenCodonSitsInMinusSegmentOfMixedStrandJoin() {
+    public void testMixedStrandJoinIsJudgedRowByRow() {
+        // Both rows of one feature carry the same value, but only the minus row spans the position.
+        // Judging each row on its own must not raise a false positive from the unrelated plus row.
         String value = "(pos:complement(4370..4372),aa:Sec)";
-        gff3Annotation.addFeature(
-                featureOnStrand("c1", OntologyTerm.CDS.name(), 4000, 5000, "-", TRANSL_EXCEPT, value));
-        gff3Annotation.addFeature(
-                featureOnStrand("c1", OntologyTerm.CDS.name(), 6000, 7000, "+", TRANSL_EXCEPT, value));
+        GFF3Feature minusRow = featureOnStrand("c1", OntologyTerm.CDS.name(), 4000, 5000, "-", TRANSL_EXCEPT, value);
+        GFF3Feature plusRow = featureOnStrand("c1", OntologyTerm.CDS.name(), 6000, 7000, "+", TRANSL_EXCEPT, value);
 
-        // Only the row whose start/end span the position decides. The other row of the same
-        // feature carries a different strand, which must not trigger a false positive.
         Assertions.assertDoesNotThrow(
-                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
+                () -> attributesLocationValidation.validateTranslExceptStrandConflict(minusRow, 1));
+        Assertions.assertDoesNotThrow(
+                () -> attributesLocationValidation.validateTranslExceptStrandConflict(plusRow, 1));
     }
 
     @Test
     public void testNoStrandConflictWithoutAComplementWrapper() {
-        gff3Annotation.addFeature(featureOnStrand(
-                "c1", OntologyTerm.CDS.name(), 4000, 5000, "+", TRANSL_EXCEPT, "(pos:4370..4372,aa:Sec)"));
+        GFF3Feature cds = featureOnStrand(
+                "c1", OntologyTerm.CDS.name(), 4000, 5000, "+", TRANSL_EXCEPT, "(pos:4370..4372,aa:Sec)");
 
-        Assertions.assertDoesNotThrow(
-                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
+        Assertions.assertDoesNotThrow(() -> attributesLocationValidation.validateTranslExceptStrandConflict(cds, 1));
     }
 
     @Test
     public void testStrandConflictLeavesMalformedValuesToTheLocationRule() {
-        gff3Annotation.addFeature(featureOnStrand(
-                "c1", OntologyTerm.CDS.name(), 4000, 5000, "+", TRANSL_EXCEPT, "(pos:complement(abc),aa:Sec)"));
+        GFF3Feature cds = featureOnStrand(
+                "c1", OntologyTerm.CDS.name(), 4000, 5000, "+", TRANSL_EXCEPT, "(pos:complement(abc),aa:Sec)");
 
         // An unparseable location is TRANSL_EXCEPT_LOCATION's business, not this rule's.
-        Assertions.assertDoesNotThrow(
-                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
+        Assertions.assertDoesNotThrow(() -> attributesLocationValidation.validateTranslExceptStrandConflict(cds, 1));
     }
 
     @Test
@@ -694,11 +684,10 @@ public class AttributesLocationValidationTest {
         // is skipped as unparseable, so the test would still pass even if the rule were wrongly
         // extended to anticodon. Seq-less it parses cleanly, leaving the attribute filter as the
         // only thing preventing a conflict being reported.
-        gff3Annotation.addFeature(featureOnStrand(
-                "t1", OntologyTerm.TRNA.name(), 4200, 4300, "+", ANTI_CODON, "(pos:complement(4229..4231),aa:Lys)"));
+        GFF3Feature tRna = featureOnStrand(
+                "t1", OntologyTerm.TRNA.name(), 4200, 4300, "+", ANTI_CODON, "(pos:complement(4229..4231),aa:Lys)");
 
-        Assertions.assertDoesNotThrow(
-                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
+        Assertions.assertDoesNotThrow(() -> attributesLocationValidation.validateTranslExceptStrandConflict(tRna, 1));
     }
 
     private GFF3Feature featureOnStrand(

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/AttributesLocationValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/AttributesLocationValidationTest.java
@@ -12,8 +12,10 @@ package uk.ac.ebi.embl.gff3tools.validation.builtin;
 
 import static uk.ac.ebi.embl.gff3tools.gff3.GFF3Attributes.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -585,5 +587,138 @@ public class AttributesLocationValidationTest {
         Assertions.assertTrue(ex.getMessage()
                 .contains("%s location %s..%s is outside feature range %s..%s"
                         .formatted(TRANSL_EXCEPT, "1000", "1002", f1.getStart(), f2.getEnd())));
+    }
+
+    // -----------------------------------------------------------------
+    // TRANSL_EXCEPT_STRAND_CONFLICT
+    //
+    // Reports a complement(...) wrapper that TRANSL_EXCEPT_COMPLEMENT refused to strip, i.e. one
+    // whose direction cannot be shown to agree with the feature's strand. Note these features are
+    // built directly rather than through TestUtils, because every TestUtils factory hardcodes
+    // strand "+" and strand is precisely what this rule turns on.
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testStrandConflictReportedWhenComplementSitsOnPlusStrand() {
+        String value = "(pos:complement(4370..4372),aa:Sec)";
+        gff3Annotation.addFeature(
+                featureOnStrand("c1", OntologyTerm.CDS.name(), 4000, 5000, "+", TRANSL_EXCEPT, value));
+
+        ValidationException ex = Assertions.assertThrows(
+                ValidationException.class,
+                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
+
+        Assertions.assertTrue(ex.getMessage()
+                .contains("%s location is wrapped in complement() but the containing feature is on strand \"%s\": %s"
+                        .formatted(TRANSL_EXCEPT, "+", value)));
+    }
+
+    @Test
+    public void testStrandConflictReportedWhenStrandIsUnknown() {
+        String value = "(pos:complement(4370..4372),aa:Sec)";
+        gff3Annotation.addFeature(
+                featureOnStrand("c1", OntologyTerm.CDS.name(), 4000, 5000, ".", TRANSL_EXCEPT, value));
+
+        ValidationException ex = Assertions.assertThrows(
+                ValidationException.class,
+                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
+
+        // Redundancy is unprovable on an unknown strand, so the wrapper is reported rather than
+        // quietly accepted.
+        Assertions.assertTrue(ex.getMessage().contains("on strand \".\""));
+    }
+
+    @Test
+    public void testStrandConflictReportedWhenCodonMatchesNoFragment() {
+        String value = "(pos:complement(9000..9002),aa:Sec)";
+        gff3Annotation.addFeature(
+                featureOnStrand("c1", OntologyTerm.CDS.name(), 4000, 5000, "-", TRANSL_EXCEPT, value));
+
+        ValidationException ex = Assertions.assertThrows(
+                ValidationException.class,
+                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
+
+        Assertions.assertTrue(ex.getMessage()
+                .contains("%s location is wrapped in complement() but does not fall within any feature fragment: %s"
+                        .formatted(TRANSL_EXCEPT, value)));
+    }
+
+    @Test
+    public void testNoStrandConflictWhenComplementAgreesWithMinusStrand() {
+        gff3Annotation.addFeature(featureOnStrand(
+                "c1", OntologyTerm.CDS.name(), 4000, 5000, "-", TRANSL_EXCEPT, "(pos:complement(4370..4372),aa:Sec)"));
+
+        // The wrapper merely duplicates column 7 here, so there is nothing to report.
+        Assertions.assertDoesNotThrow(
+                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
+    }
+
+    @Test
+    public void testNoStrandConflictWhenCodonSitsInMinusSegmentOfMixedStrandJoin() {
+        String value = "(pos:complement(4370..4372),aa:Sec)";
+        gff3Annotation.addFeature(
+                featureOnStrand("c1", OntologyTerm.CDS.name(), 4000, 5000, "-", TRANSL_EXCEPT, value));
+        gff3Annotation.addFeature(
+                featureOnStrand("c1", OntologyTerm.CDS.name(), 6000, 7000, "+", TRANSL_EXCEPT, value));
+
+        // Only the fragment actually containing the codon decides; the unrelated + segment of a
+        // trans-spliced join must not trigger a false positive.
+        Assertions.assertDoesNotThrow(
+                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
+    }
+
+    @Test
+    public void testNoStrandConflictWithoutAComplementWrapper() {
+        gff3Annotation.addFeature(featureOnStrand(
+                "c1", OntologyTerm.CDS.name(), 4000, 5000, "+", TRANSL_EXCEPT, "(pos:4370..4372,aa:Sec)"));
+
+        Assertions.assertDoesNotThrow(
+                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
+    }
+
+    @Test
+    public void testStrandConflictLeavesMalformedValuesToTheLocationRule() {
+        gff3Annotation.addFeature(featureOnStrand(
+                "c1", OntologyTerm.CDS.name(), 4000, 5000, "+", TRANSL_EXCEPT, "(pos:complement(abc),aa:Sec)"));
+
+        // An unparseable location is TRANSL_EXCEPT_LOCATION's business, not this rule's.
+        Assertions.assertDoesNotThrow(
+                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
+    }
+
+    @Test
+    public void testStrandConflictNeverAppliesToAntiCodon() {
+        // There is deliberately no anticodon counterpart: sequencetools consumes that complement
+        // flag to re-extract the seq: payload, so it is meaningful rather than redundant.
+        //
+        // The value is deliberately written WITHOUT a seq: part. With one, it fails the
+        // transl_except grammar (which forbids a second comma) and would be skipped as
+        // unparseable - so the test would pass even if the rule were wrongly extended to
+        // anticodon. Seq-less, it parses cleanly and sits inside the feature on a + strand, so
+        // the attribute filter is the only thing standing between it and a reported conflict.
+        gff3Annotation.addFeature(featureOnStrand(
+                "t1", OntologyTerm.TRNA.name(), 4200, 4300, "+", ANTI_CODON, "(pos:complement(4229..4231),aa:Lys)"));
+
+        Assertions.assertDoesNotThrow(
+                () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
+    }
+
+    private GFF3Feature featureOnStrand(
+            String id, String name, long start, long end, String strand, String attribute, String... values) {
+
+        GFF3Feature feature = new GFF3Feature(
+                Optional.of(id),
+                Optional.empty(),
+                TestUtils.DEFAULT_ACCESSION,
+                Optional.empty(),
+                ".",
+                name,
+                start,
+                end,
+                ".",
+                strand,
+                "0");
+        feature.setAttributeList(attribute, new ArrayList<>(List.of(values)));
+        return feature;
     }
 }

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/AttributesLocationValidationTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/builtin/AttributesLocationValidationTest.java
@@ -592,10 +592,10 @@ public class AttributesLocationValidationTest {
     // -----------------------------------------------------------------
     // TRANSL_EXCEPT_STRAND_CONFLICT
     //
-    // Reports a complement(...) wrapper that TRANSL_EXCEPT_COMPLEMENT refused to strip, i.e. one
-    // whose direction cannot be shown to agree with the feature's strand. Note these features are
-    // built directly rather than through TestUtils, because every TestUtils factory hardcodes
-    // strand "+" and strand is precisely what this rule turns on.
+    // Reports a complement(...) wrapper in a transl_except value that TRANSL_EXCEPT_COMPLEMENT
+    // declined to remove, because the row's strand column does not confirm dropping it is safe.
+    // These features are built directly rather than via TestUtils, whose factories all hardcode
+    // strand "+" - and strand is exactly what this rule keys on.
     // -----------------------------------------------------------------
 
     @Test
@@ -623,8 +623,8 @@ public class AttributesLocationValidationTest {
                 ValidationException.class,
                 () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
 
-        // Redundancy is unprovable on an unknown strand, so the wrapper is reported rather than
-        // quietly accepted.
+        // A "." strand states no direction at all, so the wrapper cannot be confirmed and is
+        // reported rather than quietly accepted.
         Assertions.assertTrue(ex.getMessage().contains("on strand \".\""));
     }
 
@@ -648,7 +648,7 @@ public class AttributesLocationValidationTest {
         gff3Annotation.addFeature(featureOnStrand(
                 "c1", OntologyTerm.CDS.name(), 4000, 5000, "-", TRANSL_EXCEPT, "(pos:complement(4370..4372),aa:Sec)"));
 
-        // The wrapper merely duplicates column 7 here, so there is nothing to report.
+        // Here the wrapper and the strand column agree, so there is nothing to report.
         Assertions.assertDoesNotThrow(
                 () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
     }
@@ -661,8 +661,8 @@ public class AttributesLocationValidationTest {
         gff3Annotation.addFeature(
                 featureOnStrand("c1", OntologyTerm.CDS.name(), 6000, 7000, "+", TRANSL_EXCEPT, value));
 
-        // Only the fragment actually containing the codon decides; the unrelated + segment of a
-        // trans-spliced join must not trigger a false positive.
+        // Only the row whose start/end span the position decides. The other row of the same
+        // feature carries a different strand, which must not trigger a false positive.
         Assertions.assertDoesNotThrow(
                 () -> attributesLocationValidation.validateTranslExceptStrandConflict(gff3Annotation, 1));
     }
@@ -688,14 +688,12 @@ public class AttributesLocationValidationTest {
 
     @Test
     public void testStrandConflictNeverAppliesToAntiCodon() {
-        // There is deliberately no anticodon counterpart: sequencetools consumes that complement
-        // flag to re-extract the seq: payload, so it is meaningful rather than redundant.
+        // The lookalike anticodon attribute must never be reported by this rule.
         //
-        // The value is deliberately written WITHOUT a seq: part. With one, it fails the
-        // transl_except grammar (which forbids a second comma) and would be skipped as
-        // unparseable - so the test would pass even if the rule were wrongly extended to
-        // anticodon. Seq-less, it parses cleanly and sits inside the feature on a + strand, so
-        // the attribute filter is the only thing standing between it and a reported conflict.
+        // Keep this value free of a seq: part: with one it fails the transl_except format check and
+        // is skipped as unparseable, so the test would still pass even if the rule were wrongly
+        // extended to anticodon. Seq-less it parses cleanly, leaving the attribute filter as the
+        // only thing preventing a conflict being reported.
         gff3Annotation.addFeature(featureOnStrand(
                 "t1", OntologyTerm.TRNA.name(), 4200, 4300, "+", ANTI_CODON, "(pos:complement(4229..4231),aa:Lys)"));
 

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFixTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFixTest.java
@@ -26,9 +26,10 @@ import uk.ac.ebi.embl.gff3tools.gff3.GFF3Feature;
 import uk.ac.ebi.embl.gff3tools.utils.OntologyTerm;
 
 /**
- * The fix removes a {@code complement(...)} wrapper from a {@code transl_except} feature attribute only
- * where it is provably redundant with the feature's strand. These tests pin both halves of that:
- * what is rewritten, and — more importantly — everything that must be left alone.
+ * The fix drops a {@code complement(...)} wrapper from {@code transl_except} attribute values, so
+ * {@code (pos:complement(4370..4372),aa:Sec)} becomes {@code (pos:4370..4372,aa:Sec)} — but only
+ * when the row's strand column confirms that is safe. These tests cover both halves: what gets
+ * rewritten, and the much larger set of cases that must be left exactly as they are.
  */
 public class TranslExceptComplementFixTest {
 
@@ -45,7 +46,7 @@ public class TranslExceptComplementFixTest {
     }
 
     // ---------------------------------------------------------------------
-    // Stripping, where the wrapper is provably redundant
+    // Values that should be rewritten
     // ---------------------------------------------------------------------
 
     @Test
@@ -112,7 +113,7 @@ public class TranslExceptComplementFixTest {
     }
 
     // ---------------------------------------------------------------------
-    // Refusals: the wrapper must survive wherever redundancy is unprovable
+    // Values that must be left exactly as they are
     // ---------------------------------------------------------------------
 
     @Test
@@ -123,8 +124,9 @@ public class TranslExceptComplementFixTest {
 
         fix.fixAnnotation(annotation, 1);
 
-        // Stripping here would silently resolve a genuine contradiction in favour of the strand
-        // column; TRANSL_EXCEPT_STRAND_CONFLICT reports it instead.
+        // The wrapper says "backwards" but the strand column says "forwards", so one of them is
+        // wrong. Rewriting would hide that, so the value stays put and TRANSL_EXCEPT_STRAND_CONFLICT
+        // reports it instead.
         assertEquals(List.of(value), translExcept(cds));
     }
 
@@ -183,8 +185,7 @@ public class TranslExceptComplementFixTest {
         annotation.addFeature(a);
         annotation.addFeature(b);
 
-        // A fix must never propagate an exception: executeFixes turns any escape into a hard
-        // error that --rules cannot suppress.
+        // Values the fix cannot parse are skipped, so one malformed row can never abort the run.
         assertDoesNotThrow(() -> fix.fixAnnotation(annotation, 1));
 
         assertEquals(List.of(malformed), translExcept(a));
@@ -192,12 +193,12 @@ public class TranslExceptComplementFixTest {
     }
 
     // ---------------------------------------------------------------------
-    // Joins: the decision is made per ID-group, never per row
+    // One feature spread over several rows (a join)
     // ---------------------------------------------------------------------
 
     @Test
     public void testUniformMinusStrandJoinRewritesEveryRowIdentically() {
-        // GFF3AnnotationFactory replicates the attribute onto every row of a join.
+        // Rows sharing an ID are one feature, and each row carries its own copy of the attribute.
         String value = "(pos:complement(4370..4372),aa:Sec)";
         GFF3Feature first = cds("c1", 4000, 5000, MINUS, value);
         GFF3Feature second = cds("c1", 6000, 7000, MINUS, value);
@@ -220,7 +221,8 @@ public class TranslExceptComplementFixTest {
 
         fix.fixAnnotation(annotation, 1);
 
-        // Containment - not "the whole group is minus" - keeps a trans-spliced join fixable.
+        // Only the row whose start/end span the position decides, so the other row's strand is
+        // irrelevant here.
         assertEquals(List.of("(pos:4370..4372,aa:Sec)"), translExcept(minusSegment));
         assertEquals(translExcept(minusSegment), translExcept(plusSegment));
     }
@@ -240,14 +242,14 @@ public class TranslExceptComplementFixTest {
     }
 
     // ---------------------------------------------------------------------
-    // Guard: anticodon is never touched
+    // Guard: the lookalike anticodon attribute is never touched
     // ---------------------------------------------------------------------
 
     @Test
     public void testNeverTouchesAntiCodon() {
-        // sequencetools re-extracts the seq: payload through SegmentFactory using the anticodon
-        // location's own complement flag, so stripping it there would make the value internally
-        // false. transl_except carries no such direction-dependent payload.
+        // The anticodon attribute looks almost identical but must never be rewritten: it has an
+        // extra seq: part that other EBI tooling recomputes from the wrapper, so dropping the
+        // wrapper would change what the value says.
         String value = "(pos:complement(4229..4231),aa:Lys,seq:ttt)";
         GFF3Feature tRna = new GFF3Feature(
                 Optional.of("t1"),

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFixTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFixTest.java
@@ -26,7 +26,7 @@ import uk.ac.ebi.embl.gff3tools.gff3.GFF3Feature;
 import uk.ac.ebi.embl.gff3tools.utils.OntologyTerm;
 
 /**
- * The fix removes a {@code complement(...)} wrapper from a {@code transl_except} location only
+ * The fix removes a {@code complement(...)} wrapper from a {@code transl_except} feature attribute only
  * where it is provably redundant with the feature's strand. These tests pin both halves of that:
  * what is rewritten, and — more importantly — everything that must be left alone.
  */

--- a/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFixTest.java
+++ b/src/test/java/uk/ac/ebi/embl/gff3tools/validation/fix/TranslExceptComplementFixTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2025 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.gff3tools.validation.fix;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.ac.ebi.embl.gff3tools.gff3.GFF3Attributes.ANTI_CODON;
+import static uk.ac.ebi.embl.gff3tools.gff3.GFF3Attributes.TRANSL_EXCEPT;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.embl.gff3tools.TestUtils;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Annotation;
+import uk.ac.ebi.embl.gff3tools.gff3.GFF3Feature;
+import uk.ac.ebi.embl.gff3tools.utils.OntologyTerm;
+
+/**
+ * The fix removes a {@code complement(...)} wrapper from a {@code transl_except} location only
+ * where it is provably redundant with the feature's strand. These tests pin both halves of that:
+ * what is rewritten, and — more importantly — everything that must be left alone.
+ */
+public class TranslExceptComplementFixTest {
+
+    private static final String MINUS = "-";
+    private static final String PLUS = "+";
+
+    private TranslExceptComplementFix fix;
+    private GFF3Annotation annotation;
+
+    @BeforeEach
+    public void setUp() {
+        fix = new TranslExceptComplementFix();
+        annotation = new GFF3Annotation();
+    }
+
+    // ---------------------------------------------------------------------
+    // Stripping, where the wrapper is provably redundant
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void testStripsComplementOnMinusStrandFeature() {
+        GFF3Feature cds = cds("c1", 4000, 5000, MINUS, "(pos:complement(4370..4372),aa:Sec)");
+        annotation.addFeature(cds);
+
+        fix.fixAnnotation(annotation, 1);
+
+        assertEquals(List.of("(pos:4370..4372,aa:Sec)"), translExcept(cds));
+    }
+
+    @Test
+    public void testStripsSinglePositionComplement() {
+        GFF3Feature cds = cds("c1", 1, 800, MINUS, "(pos:complement(213),aa:Met)");
+        annotation.addFeature(cds);
+
+        fix.fixAnnotation(annotation, 1);
+
+        assertEquals(List.of("(pos:213,aa:Met)"), translExcept(cds));
+    }
+
+    @Test
+    public void testPreservesSpacingAndCaseOutsideTheWrapper() {
+        GFF3Feature cds = cds("c1", 4000, 5000, MINUS, "( pos : COMPLEMENT( 4370 .. 4372 ) , aa : Sec )");
+        annotation.addFeature(cds);
+
+        fix.fixAnnotation(annotation, 1);
+
+        // Only the wrapper disappears; spacing, casing and the aa: token survive untouched.
+        assertEquals(List.of("( pos : 4370 .. 4372 , aa : Sec )"), translExcept(cds));
+    }
+
+    @Test
+    public void testRewritesOnlyTheWrappedValueAndPreservesOrder() {
+        GFF3Feature cds = cds(
+                "c1",
+                4000,
+                5000,
+                MINUS,
+                "(pos:4100..4102,aa:Trp)",
+                "(pos:complement(4370..4372),aa:Sec)",
+                "(pos:4500..4502,aa:Trp)");
+        annotation.addFeature(cds);
+
+        fix.fixAnnotation(annotation, 1);
+
+        assertEquals(
+                List.of("(pos:4100..4102,aa:Trp)", "(pos:4370..4372,aa:Sec)", "(pos:4500..4502,aa:Trp)"),
+                translExcept(cds));
+    }
+
+    @Test
+    public void testIsIdempotent() {
+        GFF3Feature cds = cds("c1", 4000, 5000, MINUS, "(pos:complement(4370..4372),aa:Sec)");
+        annotation.addFeature(cds);
+
+        fix.fixAnnotation(annotation, 1);
+        List<String> afterFirstPass = translExcept(cds);
+        fix.fixAnnotation(annotation, 1);
+
+        assertEquals(afterFirstPass, translExcept(cds));
+        assertEquals(List.of("(pos:4370..4372,aa:Sec)"), translExcept(cds));
+    }
+
+    // ---------------------------------------------------------------------
+    // Refusals: the wrapper must survive wherever redundancy is unprovable
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void testLeavesComplementOnPlusStrandFeature() {
+        String value = "(pos:complement(4370..4372),aa:Sec)";
+        GFF3Feature cds = cds("c1", 4000, 5000, PLUS, value);
+        annotation.addFeature(cds);
+
+        fix.fixAnnotation(annotation, 1);
+
+        // Stripping here would silently resolve a genuine contradiction in favour of the strand
+        // column; TRANSL_EXCEPT_STRAND_CONFLICT reports it instead.
+        assertEquals(List.of(value), translExcept(cds));
+    }
+
+    @Test
+    public void testLeavesComplementOnUnknownStrand() {
+        String value = "(pos:complement(4370..4372),aa:Sec)";
+        GFF3Feature unscored = cds("c1", 4000, 5000, ".", value);
+        GFF3Feature unknown = cds("c2", 4000, 5000, "?", value);
+        annotation.addFeature(unscored);
+        annotation.addFeature(unknown);
+
+        fix.fixAnnotation(annotation, 1);
+
+        assertEquals(List.of(value), translExcept(unscored));
+        assertEquals(List.of(value), translExcept(unknown));
+    }
+
+    @Test
+    public void testLeavesValueWhenCodonFallsOutsideEveryFragment() {
+        String value = "(pos:complement(9000..9002),aa:Sec)";
+        GFF3Feature cds = cds("c1", 4000, 5000, MINUS, value);
+        annotation.addFeature(cds);
+
+        assertDoesNotThrow(() -> fix.fixAnnotation(annotation, 1));
+        assertEquals(List.of(value), translExcept(cds));
+    }
+
+    @Test
+    public void testLeavesCompoundFuzzyAndRemoteLocations() {
+        String compound = "(pos:complement(join(4370..4372,4380..4382)),aa:Sec)";
+        String fuzzy = "(pos:complement(<4370..4372),aa:Sec)";
+        String remote = "(pos:complement(X12345.1:4370..4372),aa:Sec)";
+
+        GFF3Feature a = cds("c1", 4000, 5000, MINUS, compound);
+        GFF3Feature b = cds("c2", 4000, 5000, MINUS, fuzzy);
+        GFF3Feature c = cds("c3", 4000, 5000, MINUS, remote);
+        annotation.addFeature(a);
+        annotation.addFeature(b);
+        annotation.addFeature(c);
+
+        assertDoesNotThrow(() -> fix.fixAnnotation(annotation, 1));
+
+        // Only a simple range is ever rewritten; anything else is left for validation to judge.
+        assertEquals(List.of(compound), translExcept(a));
+        assertEquals(List.of(fuzzy), translExcept(b));
+        assertEquals(List.of(remote), translExcept(c));
+    }
+
+    @Test
+    public void testMalformedAndOutOfRangeValuesDoNotThrow() {
+        String malformed = "(pos:complement(abc),aa:Sec)";
+        String overflow = "(pos:complement(99999999999999999999..99999999999999999999),aa:Sec)";
+
+        GFF3Feature a = cds("c1", 4000, 5000, MINUS, malformed);
+        GFF3Feature b = cds("c2", 4000, 5000, MINUS, overflow);
+        annotation.addFeature(a);
+        annotation.addFeature(b);
+
+        // A fix must never propagate an exception: executeFixes turns any escape into a hard
+        // error that --rules cannot suppress.
+        assertDoesNotThrow(() -> fix.fixAnnotation(annotation, 1));
+
+        assertEquals(List.of(malformed), translExcept(a));
+        assertEquals(List.of(overflow), translExcept(b));
+    }
+
+    // ---------------------------------------------------------------------
+    // Joins: the decision is made per ID-group, never per row
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void testUniformMinusStrandJoinRewritesEveryRowIdentically() {
+        // GFF3AnnotationFactory replicates the attribute onto every row of a join.
+        String value = "(pos:complement(4370..4372),aa:Sec)";
+        GFF3Feature first = cds("c1", 4000, 5000, MINUS, value);
+        GFF3Feature second = cds("c1", 6000, 7000, MINUS, value);
+        annotation.addFeature(first);
+        annotation.addFeature(second);
+
+        fix.fixAnnotation(annotation, 1);
+
+        assertEquals(List.of("(pos:4370..4372,aa:Sec)"), translExcept(first));
+        assertEquals(translExcept(first), translExcept(second));
+    }
+
+    @Test
+    public void testMixedStrandJoinStripsWhenCodonSitsInMinusSegment() {
+        String value = "(pos:complement(4370..4372),aa:Sec)";
+        GFF3Feature minusSegment = cds("c1", 4000, 5000, MINUS, value);
+        GFF3Feature plusSegment = cds("c1", 6000, 7000, PLUS, value);
+        annotation.addFeature(minusSegment);
+        annotation.addFeature(plusSegment);
+
+        fix.fixAnnotation(annotation, 1);
+
+        // Containment - not "the whole group is minus" - keeps a trans-spliced join fixable.
+        assertEquals(List.of("(pos:4370..4372,aa:Sec)"), translExcept(minusSegment));
+        assertEquals(translExcept(minusSegment), translExcept(plusSegment));
+    }
+
+    @Test
+    public void testMixedStrandJoinLeavesValueWhenCodonSitsInPlusSegment() {
+        String value = "(pos:complement(6100..6102),aa:Sec)";
+        GFF3Feature minusSegment = cds("c1", 4000, 5000, MINUS, value);
+        GFF3Feature plusSegment = cds("c1", 6000, 7000, PLUS, value);
+        annotation.addFeature(minusSegment);
+        annotation.addFeature(plusSegment);
+
+        fix.fixAnnotation(annotation, 1);
+
+        assertEquals(List.of(value), translExcept(minusSegment));
+        assertEquals(List.of(value), translExcept(plusSegment));
+    }
+
+    // ---------------------------------------------------------------------
+    // Guard: anticodon is never touched
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void testNeverTouchesAntiCodon() {
+        // sequencetools re-extracts the seq: payload through SegmentFactory using the anticodon
+        // location's own complement flag, so stripping it there would make the value internally
+        // false. transl_except carries no such direction-dependent payload.
+        String value = "(pos:complement(4229..4231),aa:Lys,seq:ttt)";
+        GFF3Feature tRna = new GFF3Feature(
+                Optional.of("t1"),
+                Optional.empty(),
+                TestUtils.DEFAULT_ACCESSION,
+                Optional.empty(),
+                ".",
+                OntologyTerm.TRNA.name(),
+                4200,
+                4300,
+                ".",
+                MINUS,
+                ".");
+        tRna.setAttributeList(ANTI_CODON, new ArrayList<>(List.of(value)));
+        annotation.addFeature(tRna);
+
+        fix.fixAnnotation(annotation, 1);
+
+        assertEquals(List.of(value), tRna.getAttributeList(ANTI_CODON).orElseThrow());
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private GFF3Feature cds(String id, long start, long end, String strand, String... translExceptValues) {
+        GFF3Feature feature = new GFF3Feature(
+                Optional.of(id),
+                Optional.empty(),
+                TestUtils.DEFAULT_ACCESSION,
+                Optional.empty(),
+                ".",
+                OntologyTerm.CDS.name(),
+                start,
+                end,
+                ".",
+                strand,
+                "0");
+        feature.setAttributeList(TRANSL_EXCEPT, new ArrayList<>(List.of(translExceptValues)));
+        return feature;
+    }
+
+    private List<String> translExcept(GFF3Feature feature) {
+        return feature.getAttributeList(TRANSL_EXCEPT).orElseThrow();
+    }
+}


### PR DESCRIPTION
Adds the equivalent of Transl_exceptLocationFix.java from sequencetools into gff3tools. 

The additional strand-complement validation makes sense (no complement on non-minus strand in column 7) - verified with bioinformaticians, see gff3 clarifications table.

Relevant as this fix and checks need to execute prior to translation, and transl_except is used there. 