### PR TITLE
TTENA-282: Adding bioSamplId in the tsv context

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 base {
     archivesName = 'gff3tools'
     group = 'uk.ac.ebi.ena'
-    version = '5.0.2'
+    version = '5.0.3'
 }
 
 java {

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/tsvconverter/TSVToGFF3Converter.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/tsvconverter/TSVToGFF3Converter.java
@@ -134,6 +134,7 @@ public class TSVToGFF3Converter implements Converter {
                 if (sourceOutputPath != null) {
                     SourceFeatureDTO sourceFeature =
                             new SourceFeatureDTO(submissionId, entry.getPrimarySourceFeature());
+                    sourceFeature.setBiosampleId(entry.getBiosampleId());
                     sourceFeatures.add(sourceFeature);
                 }
 

--- a/src/main/java/uk/ac/ebi/embl/gff3tools/utils/SourceFeatureDTO.java
+++ b/src/main/java/uk/ac/ebi/embl/gff3tools/utils/SourceFeatureDTO.java
@@ -36,6 +36,10 @@ public class SourceFeatureDTO {
     private boolean transgenic;
     private Map<String, List<String>> qualifiers;
 
+    // BioSample accession resolved when ORGANISM_NAME field in TSV is a sample accession;
+    // null when ORGANISM_NAME was a scientific name or tax id.
+    private String biosampleId;
+
     public SourceFeatureDTO(String id, SourceFeature original) {
         if (original == null) {
             throw new NullPointerException("Original feature is null");


### PR DESCRIPTION
- Added BioSampleId in the sourceFeature. 
- BioSampleId will be persisted in the DBEntry table during TSV processing.
- When Annotation submitted, BioSampleID will be used to pull sample.